### PR TITLE
fix: remove click and touchstart listener in PrimitiveMenu when unmou…

### DIFF
--- a/src/components/ImportRecordsFlow/index.js
+++ b/src/components/ImportRecordsFlow/index.js
@@ -37,8 +37,6 @@ const ADD_RECORDS = Symbol('add-records');
 const MERGE_RECORDS = Symbol('merge-records');
 
 /**
- * An Accordion is a collection of vertically stacked sections with multiple content areas.
- * Allows a user to toggle the display of a section of content.
  * @category Experiences
  */
 

--- a/src/components/PrimitiveMenu/index.js
+++ b/src/components/PrimitiveMenu/index.js
@@ -38,6 +38,11 @@ export default class PrimitiveMenu extends Component {
         };
     }
 
+    componentWillUnmount() {
+        window.removeEventListener('click', this.handleClick);
+        window.removeEventListener('touchstart', this.handleClick);
+    }
+
     getContainerClassNames() {
         const { isOpen } = this.state;
         const { className } = this.props;


### PR DESCRIPTION
…nt component

<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #879 

Changes proposed in this PR:
- remove click and touchstart listener in PrimitiveMenu when unmount component


[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/90milesbridge/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@90milesbridge/tigger
