### PR TITLE
chore: change coveralls badge to use nexxtway

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,15 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2
+
+defaults: &defaults
+    working_directory: ~/repo
+    docker:
+        - image: circleci/node:11.8.0-stretch-browsers
+
 jobs:
     build_and_test:
-        docker:
-            - image: circleci/node:11.8.0-stretch-browsers
-
-        working_directory: ~/repo
+        <<: *defaults
 
         steps:
             - checkout
@@ -32,10 +35,7 @@ jobs:
             - run: yarn test --ci --maxWorkers=2 --coverage --coverageReporters=text-lcov | ./node_modules/coveralls/bin/coveralls.js
 
     integration_tests:
-        docker:
-            - image: circleci/node:11.8.0-stretch-browsers
-
-        working_directory: ~/repo
+        <<: *defaults
 
         steps:
             - checkout
@@ -72,10 +72,7 @@ jobs:
                   path: ./errorShots
 
     publish_canary:
-        docker:
-            - image: circleci/node:11.8.0-stretch-browsers
-
-        working_directory: ~/repo
+        <<: *defaults
 
         steps:
             - checkout
@@ -95,10 +92,7 @@ jobs:
             - run: yarn publish --tag next
 
     deploy_firebase:
-        docker:
-            - image: circleci/node:11.8.0-stretch-browsers
-
-        working_directory: ~/repo
+        <<: *defaults
 
         steps:
             - checkout

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ React Rainbow is a collection of components that will reliably help you build yo
 <br>
 
 [![CircleCI](https://circleci.com/gh/nexxtway/react-rainbow/tree/master.svg?style=svg)](https://circleci.com/gh/nexxtway/react-rainbow/tree/master)
-[![Coverage Status](https://coveralls.io/repos/github/nexxtway/react-rainbow/badge.svg?branch=master)](https://coveralls.io/github/nexxtway/react-rainbow-components?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/nexxtway/react-rainbow/badge.svg?branch=master)](https://coveralls.io/github/nexxtway/react-rainbow?branch=master)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm version](https://badge.fury.io/js/react-rainbow-components.svg)](https://badge.fury.io/js/react-rainbow-components)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/react-rainbow-components/community?source=orgpage)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

## Changes proposed in this PR:

## - change coveralls badge to use nexxtway

[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/tigger
