### PR TITLE
fix: placeholder common-mixin in TimePicker

### DIFF
--- a/src/components/TimePicker/styles.scss
+++ b/src/components/TimePicker/styles.scss
@@ -69,19 +69,19 @@
     }
 
     &::-webkit-input-placeholder {
-        @include animation-properties();
+        @include placeholder-common();
     }
 
     &::-moz-placeholder {
-        @include animation-properties();
+        @include placeholder-common();
     }
 
     &:-ms-input-placeholder {
-        @include animation-properties();
+        @include placeholder-common();
     }
 
     &:-moz-placeholder {
-        @include animation-properties();
+        @include placeholder-common();
     }
 
     &:focus,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

## Changes proposed in this PR:

## - fix placeholder common-mixin in TimePicker

[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/tigger
