### PR TITLE
fix: keep sync in installation page title with react version used

### DIFF
--- a/library/pages/GettingStartedPage/index.js
+++ b/library/pages/GettingStartedPage/index.js
@@ -36,6 +36,8 @@ export default class GettingStartedPage extends Component {
         super(props);
         this.state = { activeTabName: 'overview' };
         this.handleTabChange = this.handleTabChange.bind(this);
+        // eslint-disable-next-line no-undef
+        this.reactV = reactVersion[0] === '^' ? reactVersion.slice(1) : reactVersion;
     }
 
     handleTabChange(e, tabName) {
@@ -84,7 +86,9 @@ export default class GettingStartedPage extends Component {
                     <RenderIf isTrue={activeTabName === 'installation'}>
                         <div className="rainbow-flex rainbow-flex_column">
                             <h3 className="react-rainbow-getting-started_section-heading">
-                                React Rainbow Components is currently optimized for React 16.4.2
+                                {`React Rainbow Components is currently optimized for React ${
+                                    this.reactV
+                                }`}
                             </h3>
                             <h2 className="react-rainbow-getting-started_section-heading-2">
                                 Install

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -171,6 +171,9 @@ module.exports = {
         plugins: [
             new CopyWebpackPlugin([{ from: './assets/' }]),
             new webpack.DefinePlugin(envKeys),
+            new webpack.DefinePlugin({
+                reactVersion: JSON.stringify(require('./package.json').dependencies.react),
+            }),
         ],
     },
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

## Changes proposed in this PR:

## - keep sync in installation page title with react version used

[ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/tigger
