### PR TITLE
feat: add hideCloseButton to Notification component

### DIFF
--- a/src/components/Notification/__test__/notification.spec.js
+++ b/src/components/Notification/__test__/notification.spec.js
@@ -27,4 +27,8 @@ describe('<Notification/>', () => {
             'rainbow-notification my-custom-class-name',
         );
     });
+    it('should not display the close button when hideCloseButton props is true', () => {
+        const component = mount(<Notification title="Notification test" hideCloseButton />);
+        expect(component.find('ButtonIcon').exists()).toBe(false);
+    });
 });

--- a/src/components/Notification/index.js
+++ b/src/components/Notification/index.js
@@ -13,7 +13,7 @@ import './styles.css';
  * Notifications serve as a confirmation mechanism & feedback that comes into the page at the top.
  */
 export default function Notification(props) {
-    const { className, style, icon, title, description, onRequestClose } = props;
+    const { className, style, icon, title, description, onRequestClose, hideCloseButton } = props;
 
     function getClassName() {
         return classnames('rainbow-notification', className);
@@ -34,13 +34,15 @@ export default function Notification(props) {
                     </RenderIf>
                 </span>
             </a>
-            <ButtonIcon
-                className="rainbow-notification_close"
-                icon={<CloseIcon />}
-                size="small"
-                title="Close"
-                onClick={onRequestClose}
-            />
+            <RenderIf isTrue={!hideCloseButton}>
+                <ButtonIcon
+                    className="rainbow-notification_close"
+                    icon={<CloseIcon />}
+                    size="small"
+                    title="Close"
+                    onClick={onRequestClose}
+                />
+            </RenderIf>
         </div>
     );
 }
@@ -63,6 +65,8 @@ Notification.propTypes = {
     className: PropTypes.string,
     /** An object with custom style applied to the outer element. */
     style: PropTypes.object,
+    /** If true, hide the close button in the notification */
+    hideCloseButton: PropTypes.bool,
 };
 
 Notification.defaultProps = {
@@ -72,4 +76,5 @@ Notification.defaultProps = {
     onRequestClose: () => {},
     className: undefined,
     style: undefined,
+    hideCloseButton: false,
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

Hello! This is my first PR adding a small feature to your awesome project. Thanks.

## Changes proposed in this PR:
- Add `hideCloseButton` props to `Notification` component, which may be useful in cases that we want to make the component stay on the screen.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
