### PR TITLE
fix: make the first google option selected by default

### DIFF
--- a/src/components/GoogleAddressLookup/component.js
+++ b/src/components/GoogleAddressLookup/component.js
@@ -201,6 +201,7 @@ class PlacesLookupComponent extends Component {
                     onBlur={onBlur}
                     error={error}
                     icon={<LocationIcon />}
+                    preferredSelectedOption={1}
                 />
                 <RenderIf isTrue={!error}>
                     <div className="rainbow-google-address-lookup_powered-by-google-container">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #788 

## Changes proposed in this PR:
- make the first google option selected by default in the GoogleAddressLookup component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
