### PR TITLE
refactor: migrate ActivityTimeline styled components

### DIFF
--- a/src/components/ActivityTimeline/__test__/activityTimeline.spec.js
+++ b/src/components/ActivityTimeline/__test__/activityTimeline.spec.js
@@ -4,12 +4,6 @@ import ActivityTimeline from './../index';
 import Card from './../../Card';
 
 describe('<ActivityTimeline/>', () => {
-    it('should have the right class names when a custom class name is passed', () => {
-        const component = mount(<ActivityTimeline className="testing_activityTimeline" />);
-        expect(component.find('ul').prop('className')).toBe(
-            'rainbow-activity-timeline_container testing_activityTimeline',
-        );
-    });
     it('should render the children passed', () => {
         const component = mount(
             <ActivityTimeline>

--- a/src/components/ActivityTimeline/__test__/activityTimeline.spec.js
+++ b/src/components/ActivityTimeline/__test__/activityTimeline.spec.js
@@ -4,10 +4,6 @@ import ActivityTimeline from './../index';
 import Card from './../../Card';
 
 describe('<ActivityTimeline/>', () => {
-    it('should have the right class names', () => {
-        const component = mount(<ActivityTimeline />);
-        expect(component.find('ul').prop('className')).toBe('rainbow-activity-timeline_container');
-    });
     it('should have the right class names when a custom class name is passed', () => {
         const component = mount(<ActivityTimeline className="testing_activityTimeline" />);
         expect(component.find('ul').prop('className')).toBe(

--- a/src/components/ActivityTimeline/index.js
+++ b/src/components/ActivityTimeline/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import './styles.css';
+import StyledContainer from './styled/container';
 
 /**
  * The ActivityTimeline displays each of any item upcoming, current, and past activities.
@@ -10,13 +9,10 @@ import './styles.css';
 export default function ActivityTimeline(props) {
     const { children, className, style } = props;
 
-    const getContainerClassName = () =>
-        classnames('rainbow-activity-timeline_container', className);
-
     return (
-        <ul className={getContainerClassName()} style={style}>
+        <StyledContainer className={className} style={style}>
             {children}
-        </ul>
+        </StyledContainer>
     );
 }
 

--- a/src/components/ActivityTimeline/styled/container.js
+++ b/src/components/ActivityTimeline/styled/container.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const StyledContainer = styled.ul`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+`;
+
+export default StyledContainer;

--- a/src/components/ActivityTimeline/styles.css
+++ b/src/components/ActivityTimeline/styles.css
@@ -1,4 +1,0 @@
-.rainbow-activity-timeline_container {
-  display: flex;
-  flex-direction: column;
-  width: 100%; }

--- a/src/components/ActivityTimeline/styles.scss
+++ b/src/components/ActivityTimeline/styles.scss
@@ -1,5 +1,0 @@
-.rainbow-activity-timeline_container {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

#950 

## Changes proposed in this PR:
- Migrate ActivityTimeline to styled-components

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
