### PR TITLE
feat: add hideCloseButton prop to modal component

### DIFF
--- a/src/components/Modal/__test__/modal.spec.js
+++ b/src/components/Modal/__test__/modal.spec.js
@@ -187,4 +187,24 @@ describe('<Modal/>', () => {
         component.unmount();
         expect(CounterManager.decrement).not.toHaveBeenCalled();
     });
+    it('should show the cross for close the modal by default', () => {
+        const component = mount(
+            <Modal isOpen>
+                <p />
+            </Modal>,
+        );
+
+        expect(component.find('button[data-id="button-icon-element"]').prop('id')).toBe(
+            'modal-close-button',
+        );
+    });
+    it('should not render the cross for close the modal when the showClose prop is equal to false', () => {
+        const component = mount(
+            <Modal isOpen showClose={false}>
+                <p />
+            </Modal>,
+        );
+
+        expect(component.exists('button[data-id="button-icon-element"]')).toBeFalsy();
+    });
 });

--- a/src/components/Modal/__test__/modal.spec.js
+++ b/src/components/Modal/__test__/modal.spec.js
@@ -195,7 +195,7 @@ describe('<Modal/>', () => {
             </Modal>,
         );
 
-        expect(component.find(StyledCloseButton).exists).toBeTruthy();
+        expect(component.find(StyledCloseButton).exists()).toBe(true);
     });
     it('should not render the close button when the hideCloseButton prop is equal to true', () => {
         const component = mount(
@@ -204,6 +204,6 @@ describe('<Modal/>', () => {
             </Modal>,
         );
 
-        expect(component.find(StyledCloseButton).exists()).toBeFalsy();
+        expect(component.find(StyledCloseButton).exists()).toBe(false);
     });
 });

--- a/src/components/Modal/__test__/modal.spec.js
+++ b/src/components/Modal/__test__/modal.spec.js
@@ -4,6 +4,7 @@ import CounterManager from '../counterManager';
 import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from '../scrollController';
 import Modal from '../';
 import StyledContent from '../styled/content';
+import StyledCloseButton from '../styled/closeButton';
 
 jest.mock('../counterManager', () => ({
     increment: jest.fn(),
@@ -187,24 +188,22 @@ describe('<Modal/>', () => {
         component.unmount();
         expect(CounterManager.decrement).not.toHaveBeenCalled();
     });
-    it('should show the cross for close the modal by default', () => {
+    it('should render the close button by default', () => {
         const component = mount(
             <Modal isOpen>
                 <p />
             </Modal>,
         );
 
-        expect(component.find('button[data-id="button-icon-element"]').prop('id')).toBe(
-            'modal-close-button',
-        );
+        expect(component.find(StyledCloseButton).exists).toBeTruthy();
     });
-    it('should not render the cross for close the modal when the showClose prop is equal to false', () => {
+    it('should not render the close button when the hideCloseButton prop is equal to true', () => {
         const component = mount(
-            <Modal isOpen showClose={false}>
+            <Modal isOpen hideCloseButton>
                 <p />
             </Modal>,
         );
 
-        expect(component.exists('button[data-id="button-icon-element"]')).toBeFalsy();
+        expect(component.find(StyledCloseButton).exists()).toBeFalsy();
     });
 });

--- a/src/components/Modal/index.d.ts
+++ b/src/components/Modal/index.d.ts
@@ -10,6 +10,7 @@ export interface ModalProps extends BaseProps {
     onOpened?: () => void;
     id?: string;
     children?: ReactNode;
+    showClose?: boolean;
 }
 
 declare const Modal: ComponentType<ModalProps>;

--- a/src/components/Modal/index.d.ts
+++ b/src/components/Modal/index.d.ts
@@ -10,7 +10,7 @@ export interface ModalProps extends BaseProps {
     onOpened?: () => void;
     id?: string;
     children?: ReactNode;
-    showClose?: boolean;
+    hideCloseButton?: boolean;
 }
 
 declare const Modal: ComponentType<ModalProps>;

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -118,7 +118,7 @@ export default class Modal extends Component {
             isOpen,
             id,
             size,
-            showClose,
+            hideCloseButton,
         } = this.props;
 
         if (isOpen) {
@@ -143,7 +143,7 @@ export default class Modal extends Component {
                         className={className}
                         size={size}
                     >
-                        {showClose && (
+                        <RenderIf isTrue={!hideCloseButton}>
                             <StyledCloseButton
                                 id="modal-close-button"
                                 icon={<CloseIcon />}
@@ -151,7 +151,7 @@ export default class Modal extends Component {
                                 onClick={this.closeModal}
                                 ref={this.buttonRef}
                             />
-                        )}
+                        </RenderIf>
 
                         <Header id={this.modalHeadingId} title={title} />
 
@@ -200,8 +200,8 @@ Modal.propTypes = {
      * @ignore
      */
     children: PropTypes.node,
-    /** Determines if the cross for close is showed or not */
-    showClose: PropTypes.bool,
+    /** If true, hide the close button in the modal */
+    hideCloseButton: PropTypes.bool,
 };
 
 Modal.defaultProps = {
@@ -215,5 +215,5 @@ Modal.defaultProps = {
     onRequestClose: () => {},
     onOpened: () => {},
     id: undefined,
-    showClose: true,
+    hideCloseButton: false,
 };

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -109,7 +109,17 @@ export default class Modal extends Component {
     }
 
     render() {
-        const { title, style, className, children, footer, isOpen, id, size } = this.props;
+        const {
+            title,
+            style,
+            className,
+            children,
+            footer,
+            isOpen,
+            id,
+            size,
+            showClose,
+        } = this.props;
 
         if (isOpen) {
             return createPortal(
@@ -133,13 +143,15 @@ export default class Modal extends Component {
                         className={className}
                         size={size}
                     >
-                        <StyledCloseButton
-                            id="modal-close-button"
-                            icon={<CloseIcon />}
-                            title="Close"
-                            onClick={this.closeModal}
-                            ref={this.buttonRef}
-                        />
+                        {showClose && (
+                            <StyledCloseButton
+                                id="modal-close-button"
+                                icon={<CloseIcon />}
+                                title="Close"
+                                onClick={this.closeModal}
+                                ref={this.buttonRef}
+                            />
+                        )}
 
                         <Header id={this.modalHeadingId} title={title} />
 
@@ -188,6 +200,8 @@ Modal.propTypes = {
      * @ignore
      */
     children: PropTypes.node,
+    /** Determines if the cross for close is showed or not */
+    showClose: PropTypes.bool,
 };
 
 Modal.defaultProps = {
@@ -201,4 +215,5 @@ Modal.defaultProps = {
     onRequestClose: () => {},
     onOpened: () => {},
     id: undefined,
+    showClose: true,
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

feat: add hideCloseButton prop to modal component

## Changes proposed in this PR:
- Added to modal component a new optional prop called hideCloseButton, this allows to control whether the component for close the modal should render or not
- The necessary tests have been added

Issue related #1108 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
