### PR TITLE
chore: add eslint defaultProps not defined

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
         "react/jsx-first-prop-new-line": "off",
         "react/jsx-closing-bracket-location": "off",
         "react/forbid-prop-types": "off",
+        "react/require-default-props": 2,
         "no-mixed-operators": "off",
         "arrow-parens": ["error", "as-needed"]
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

chore: add eslint rule for throw error for optional props that are not defined in defaultProps

## Changes proposed in this PR:
- Enforce a defaultProps definition for every prop that is not a required prop (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-default-props.md)

Related issue #848 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
