### PR TITLE
fix: style type and import MouseEvent

### DIFF
--- a/src/components/GoogleAddressLookup/index.d.ts
+++ b/src/components/GoogleAddressLookup/index.d.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, MouseEvent } from 'react';
 import { BaseProps, LookupValue } from '../types';
 
 interface MatchedSubstringsShape {

--- a/src/components/types.d.ts
+++ b/src/components/types.d.ts
@@ -1,8 +1,8 @@
-import { ReactNode } from 'react';
+import { ReactNode, CSSProperties } from 'react';
 
 export interface BaseProps {
     className?: string;
-    style?: CSS.style;
+    style?: CSSProperties;
 }
 
 export type AvatarSize = 'x-small' | 'small' | 'medium' | 'large';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: # 1176

## Changes proposed in this PR:
- fix style type and import MouseEvent in GoogleAddressLookup declaration file

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
