### PR TITLE
fix: end of lines issue in Windows OS

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,8 @@
         "react/jsx-closing-bracket-location": "off",
         "react/forbid-prop-types": "off",
         "no-mixed-operators": "off",
-        "arrow-parens": ["error", "as-needed"]
+        "arrow-parens": ["error", "as-needed"],
+        "linebreak-style": 0
     },
     "env": {
         "es6": true,


### PR DESCRIPTION
fix: #1183 

## Changes proposed in this PR:
- No checking of end of lines in Windows OS

- [ X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
