### PR TITLE
chore: add eslint rule to match default props and prop types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,8 @@
         "react/forbid-prop-types": "off",
         "no-mixed-operators": "off",
         "arrow-parens": ["error", "as-needed"],
-        "linebreak-style": 0
+        "linebreak-style": 0,
+        "react/default-props-match-prop-types": ["error", { "allowRequiredDefaults": true }]
     },
     "env": {
         "es6": true,


### PR DESCRIPTION
#848 

## Changes proposed in this PR:
- Add an EsLint rule to complains about defaultProps that are not defined in PropTypes

- [ X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
