### PR TITLE
fix: warning "Function components cannot be given refs." on DatePicker component

### DIFF
--- a/src/components/DatePicker/index.js
+++ b/src/components/DatePicker/index.js
@@ -165,13 +165,11 @@ class DatePickerComponent extends Component {
     }
 }
 
-function DatePicker({ locale, ...rest }) {
-    return (
-        <Consumer>
-            {values => <DatePickerComponent locale={getLocale(values, locale)} {...rest} />}
-        </Consumer>
-    );
-}
+const DatePicker = React.forwardRef(({ locale, ...rest }, ref) => (
+    <Consumer>
+        {values => <DatePickerComponent ref={ref} locale={getLocale(values, locale)} {...rest} />}
+    </Consumer>
+));
 
 DatePicker.propTypes = {
     /** Sets the date for the DatePicker programmatically. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1277 

## Changes proposed in this PR:
- fix warning 'Function components cannot be given refs.' on DatePicker component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
