### PR TITLE
fix: TimePicker when use 24hour format, put 00 in hour input and blur it

### DIFF
--- a/src/components/TimePicker/__test__/timeSelect.spec.js
+++ b/src/components/TimePicker/__test__/timeSelect.spec.js
@@ -666,4 +666,12 @@ describe('<TimeSelect/>', () => {
         const inputs = component.find('input');
         expect(inputs.length).toBe(2);
     });
+    it('should set hour value to "00" when hour24 is true, hour input is focused, type 0 and then blur the hour input', () => {
+        const component = mount(<TimeSelect hour24 />);
+        const hourInput = component.find('input').at(0);
+        hourInput.simulate('focus');
+        hourInput.simulate('change', { target: { value: '0' } });
+        hourInput.simulate('blur');
+        expect(component.state().hour).toBe('00');
+    });
 });

--- a/src/components/TimePicker/timeSelect.js
+++ b/src/components/TimePicker/timeSelect.js
@@ -147,6 +147,7 @@ export default class TimeSelect extends Component {
 
     handleBlurHour() {
         const { hour } = this.state;
+        const { hour24 } = this.props;
         if (this.isUpOrDownButtonPressed) {
             this.isUpOrDownButtonPressed = false;
             return;
@@ -155,7 +156,7 @@ export default class TimeSelect extends Component {
             this.isMinutesInputFocused = false;
             return;
         }
-        if (hour === '00' && this.value >= '0') {
+        if (hour === '00' && this.value >= '0' && !hour24) {
             this.setState({
                 hour: '12',
             });


### PR DESCRIPTION
fix: #1347

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
