### PR TITLE
fix: prop icon on AvatarGroup

### DIFF
--- a/src/components/AvatarGroup/index.js
+++ b/src/components/AvatarGroup/index.js
@@ -40,7 +40,7 @@ AvatarGroup.propTypes = {
         PropTypes.shape({
             src: PropTypes.string,
             initials: PropTypes.string,
-            icon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+            icon: PropTypes.node,
             title: PropTypes.string,
             assistiveText: PropTypes.string,
         }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1352

## Changes proposed in this PR:
- fix prop icon on the app in AvatarGroup

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
