### PR TITLE
fix: add background alpha to progressBar component elements

### DIFF
--- a/src/components/ProgressBar/styled/bar.js
+++ b/src/components/ProgressBar/styled/bar.js
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import getTheme from '../../../styles/helpers/getTheme';
-import { replaceAlpha } from '../../../styles/helpers/color';
 
 const StyledBar = styled.span.attrs(props => {
     const theme = getTheme(props);
@@ -14,13 +13,13 @@ const StyledBar = styled.span.attrs(props => {
     };
 })`
     display: block;
-    background: ${props => replaceAlpha(props.brandMainColor, 0.7)};
+    background: ${props => props.brandMainColor};
     height: 100%;
     border-radius: 1rem;
     ${props =>
         props.variant === 'success' &&
         `
-            background: ${replaceAlpha(props.successMainColor, 0.7)};
+            background: ${props.successMainColor};
         `};
 `;
 

--- a/src/components/ProgressBar/styled/bar.js
+++ b/src/components/ProgressBar/styled/bar.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import getTheme from '../../../styles/helpers/getTheme';
+import { replaceAlpha } from '../../../styles/helpers/color';
 
 const StyledBar = styled.span.attrs(props => {
     const theme = getTheme(props);
@@ -13,13 +14,13 @@ const StyledBar = styled.span.attrs(props => {
     };
 })`
     display: block;
-    background: ${props => props.brandMainColor};
+    background: ${props => replaceAlpha(props.brandMainColor, 0.7)};
     height: 100%;
     border-radius: 1rem;
     ${props =>
         props.variant === 'success' &&
         `
-            background: ${props.successMainColor};
+            background: ${replaceAlpha(props.successMainColor, 0.7)};
         `};
 `;
 

--- a/src/components/ProgressBar/styled/container.js
+++ b/src/components/ProgressBar/styled/container.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import getTheme from '../../../styles/helpers/getTheme';
+import { replaceAlpha } from '../../../styles/helpers/color';
 
 const StyledContainer = styled.div.attrs(props => {
     const theme = getTheme(props);
@@ -16,7 +17,7 @@ const StyledContainer = styled.div.attrs(props => {
     border: 0;
     position: relative;
     display: block;
-    background: ${props => props.brandLightColor};
+    background: ${props => replaceAlpha(props.brandLightColor, 0.7)};
     height: 0.5rem;
     border-radius: 1rem;
     ${props => props.size === 'x-small' && 'height: 0.125rem;'}
@@ -26,7 +27,7 @@ const StyledContainer = styled.div.attrs(props => {
     ${props =>
         props.variant === 'success' &&
         `
-            background: ${props.successLightColor};
+            background: ${replaceAlpha(props.successLightColor, 0.7)};
         `};
 `;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: add background alpha to progressBar component elements

--
* alpha added to background container 0.7
* alpha added to bar 0.7

@nexxtway/react-rainbow
