### PR TITLE
fix: margins global styles on table component when

### DIFF
--- a/src/components/Table/body/styled/actionCell.js
+++ b/src/components/Table/body/styled/actionCell.js
@@ -6,6 +6,7 @@ const StyledActionCell = styled.div`
     align-content: center;
     align-items: center;
     margin: auto;
+    box-sizing: border-box;
 `;
 
 export default StyledActionCell;

--- a/src/components/Table/body/styled/cellContent.js
+++ b/src/components/Table/body/styled/cellContent.js
@@ -14,6 +14,7 @@ const StyledCellContent = attachThemeAttrs(styled.div)`
     text-overflow: ellipsis;
     white-space: nowrap;
     font-weight: 400;
+    box-sizing: border-box;
 `;
 
 export default StyledCellContent;

--- a/src/components/Table/body/styled/checkboxContainer.js
+++ b/src/components/Table/body/styled/checkboxContainer.js
@@ -5,6 +5,7 @@ const StyledCheckboxContainer = styled.div`
     display: flex;
     padding: 0 15px;
     border: 1px solid transparent;
+    box-sizing: border-box;
 `;
 
 export default StyledCheckboxContainer;

--- a/src/components/Table/body/styled/emptyContainer.js
+++ b/src/components/Table/body/styled/emptyContainer.js
@@ -8,6 +8,7 @@ const StyledEmptyContainer = styled.div`
     width: 100%;
     height: 100%;
     margin: 32px auto;
+    box-sizing: border-box;
 `;
 
 export default StyledEmptyContainer;

--- a/src/components/Table/body/styled/loadingCell.js
+++ b/src/components/Table/body/styled/loadingCell.js
@@ -6,6 +6,7 @@ const StyledLoadingCell = styled.div`
     display: flex;
     align-items: center;
     padding: 0 24px 0 8px;
+    box-sizing: border-box;
 `;
 
 export default StyledLoadingCell;

--- a/src/components/Table/head/styled/wrapper.js
+++ b/src/components/Table/head/styled/wrapper.js
@@ -7,6 +7,7 @@ const StyledWrapper = attachThemeAttrs(styled.div)`
     top: 0;
     height: 44px;
     background-color: ${props => props.palette.background.highlight};
+    box-sizing: border-box;
 `;
 
 export default StyledWrapper;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: margin global styles are moving the margins of table component when Application wrapper is not used.

problem: when no box-sizing is added under th > div and td > div, they move the cells.

## Changes proposed in this PR:
* **th > div** and **td > div** needed "box-sizing: border-box" attributes
* updated direct components under **th** and **td** wrappers

@nexxtway/react-rainbow
