### PR TITLE
feat: add theme support for `Chart` and `Dataset` components

### DIFF
--- a/src/components/Chart/__test__/chart.a11y.spec.js
+++ b/src/components/Chart/__test__/chart.a11y.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { axe } from 'jest-axe';
-import Chart from '..';
+import { Chart } from '..';
 import Dataset from '../../Dataset';
 
 describe('<Chart/>', () => {

--- a/src/components/Chart/__test__/chart.spec.js
+++ b/src/components/Chart/__test__/chart.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import ChartJS from 'chart.js';
-import Chart from '../index';
+import { Chart } from '../index';
 import Dataset from '../../Dataset';
 
 jest.mock('chart.js', () =>

--- a/src/components/Chart/__test__/resolveOptions.spec.js
+++ b/src/components/Chart/__test__/resolveOptions.spec.js
@@ -7,7 +7,13 @@ const baseOptions = {
         fullWidth: true,
         labels: {
             usePointStyle: true,
+            fontColor: 'rgba(87, 101, 116, 1)',
         },
+    },
+    tooltips: {
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        titleFontColor: 'rgba(255, 255, 255, 1)',
+        bodyFontColor: 'rgba(255, 255, 255, 1)',
     },
 };
 
@@ -106,11 +112,25 @@ describe('resolveOptions function', () => {
                 xAxes: [
                     {
                         stacked: true,
+                        gridLines: {
+                            color: 'rgba(227, 229, 237, 1)',
+                            zeroLineColor: 'rgba(227, 229, 237, 1)',
+                        },
+                        ticks: {
+                            fontColor: 'rgba(87, 101, 116, 1)',
+                        },
                     },
                 ],
                 yAxes: [
                     {
                         stacked: true,
+                        gridLines: {
+                            color: 'rgba(227, 229, 237, 1)',
+                            zeroLineColor: 'rgba(227, 229, 237, 1)',
+                        },
+                        ticks: {
+                            fontColor: 'rgba(87, 101, 116, 1)',
+                        },
                     },
                 ],
             },
@@ -147,11 +167,25 @@ describe('resolveOptions function', () => {
                 xAxes: [
                     {
                         stacked: true,
+                        gridLines: {
+                            color: 'rgba(227, 229, 237, 1)',
+                            zeroLineColor: 'rgba(227, 229, 237, 1)',
+                        },
+                        ticks: {
+                            fontColor: 'rgba(87, 101, 116, 1)',
+                        },
                     },
                 ],
                 yAxes: [
                     {
                         stacked: true,
+                        gridLines: {
+                            color: 'rgba(227, 229, 237, 1)',
+                            zeroLineColor: 'rgba(227, 229, 237, 1)',
+                        },
+                        ticks: {
+                            fontColor: 'rgba(87, 101, 116, 1)',
+                        },
                     },
                 ],
             },

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { withTheme } from 'styled-components';
 import PropTypes from 'prop-types';
 import ChartJS from 'chart.js';
 import resolveOptions from './resolveOptions';
@@ -10,7 +11,7 @@ import StyledContainer from './styled/container';
  * You can learn more about it here:
  * @category DataView
  */
-export default class Chart extends Component {
+class Chart extends Component {
     constructor(props) {
         super(props);
         this.chartRef = React.createRef();
@@ -40,7 +41,7 @@ export default class Chart extends Component {
             this.chartInstance.config.type = type;
         }
 
-        this.chartInstance.options = resolveOptions({ ...conditions });
+        this.chartInstance.options = resolveOptions(type, { ...conditions });
         this.chartInstance.update();
     }
 
@@ -54,7 +55,7 @@ export default class Chart extends Component {
                 labels,
                 datasets: this.datasets,
             },
-            options: resolveOptions({ ...conditions }),
+            options: resolveOptions(type, { ...conditions }),
         });
     }
 
@@ -126,3 +127,5 @@ Chart.defaultProps = {
     style: undefined,
     children: undefined,
 };
+
+export default withTheme(Chart);

--- a/src/components/Chart/index.js
+++ b/src/components/Chart/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
-import { withTheme } from 'styled-components';
 import PropTypes from 'prop-types';
 import ChartJS from 'chart.js';
+import { withTheme } from 'styled-components';
 import resolveOptions from './resolveOptions';
 import resolveDatasets from './resolveDatasets';
 import StyledContainer from './styled/container';
@@ -11,7 +11,7 @@ import StyledContainer from './styled/container';
  * You can learn more about it here:
  * @category DataView
  */
-class Chart extends Component {
+export class Chart extends Component {
     constructor(props) {
         super(props);
         this.chartRef = React.createRef();
@@ -41,7 +41,7 @@ class Chart extends Component {
             this.chartInstance.config.type = type;
         }
 
-        this.chartInstance.options = resolveOptions(type, { ...conditions });
+        this.chartInstance.options = resolveOptions({ type, ...conditions });
         this.chartInstance.update();
     }
 
@@ -55,7 +55,7 @@ class Chart extends Component {
                 labels,
                 datasets: this.datasets,
             },
-            options: resolveOptions(type, { ...conditions }),
+            options: resolveOptions({ type, ...conditions }),
         });
     }
 

--- a/src/components/Chart/resolveOptions.js
+++ b/src/components/Chart/resolveOptions.js
@@ -1,4 +1,7 @@
-export default function resolveOptions(conditions) {
+import { replaceAlpha } from '../../styles/helpers/color';
+import defaultTheme from '../../styles/defaultTheme';
+
+export default function resolveOptions(type, conditions) {
     const {
         disableAnimations,
         disableLines,
@@ -7,7 +10,13 @@ export default function resolveOptions(conditions) {
         legendPosition,
         showStacked,
         maintainAspectRatio,
+        theme,
     } = conditions;
+    const palette = theme ? theme.rainbow.palette : defaultTheme.rainbow.palette;
+    const tooltips = {
+        background: replaceAlpha(palette.getContrastText(palette.background.main), 0.8),
+        color: palette.getContrastText(palette.text.main),
+    };
 
     let options = {
         maintainAspectRatio,
@@ -17,9 +26,39 @@ export default function resolveOptions(conditions) {
             fullWidth: true,
             labels: {
                 usePointStyle: true,
+                fontColor: palette.text.label,
             },
         },
+        tooltips: {
+            backgroundColor: tooltips.background,
+            titleFontColor: tooltips.color,
+            bodyFontColor: tooltips.color,
+        },
     };
+
+    if (type === 'bar' || type === 'horizontalBar' || type === 'line') {
+        options = {
+            ...options,
+            scales: {
+                xAxes: [
+                    {
+                        gridLines: {
+                            color: palette.border.divider,
+                            zeroLineColor: palette.border.divider,
+                        },
+                    },
+                ],
+                yAxes: [
+                    {
+                        gridLines: {
+                            color: palette.border.divider,
+                            zeroLineColor: palette.border.divider,
+                        },
+                    },
+                ],
+            },
+        };
+    }
 
     if (disableAnimations) {
         options = {
@@ -56,11 +95,19 @@ export default function resolveOptions(conditions) {
                 xAxes: [
                     {
                         stacked: true,
+                        gridLines: {
+                            color: palette.border.divider,
+                            zeroLineColor: palette.border.divider,
+                        },
                     },
                 ],
                 yAxes: [
                     {
                         stacked: true,
+                        gridLines: {
+                            color: palette.border.divider,
+                            zeroLineColor: palette.border.divider,
+                        },
                     },
                 ],
             },

--- a/src/components/Chart/resolveOptions.js
+++ b/src/components/Chart/resolveOptions.js
@@ -1,7 +1,7 @@
 import { replaceAlpha } from '../../styles/helpers/color';
 import defaultTheme from '../../styles/defaultTheme';
 
-export default function resolveOptions(type, conditions) {
+export default function resolveOptions(conditions) {
     const {
         disableAnimations,
         disableLines,
@@ -11,8 +11,13 @@ export default function resolveOptions(type, conditions) {
         showStacked,
         maintainAspectRatio,
         theme,
+        type,
     } = conditions;
-    const palette = theme ? theme.rainbow.palette : defaultTheme.rainbow.palette;
+    const palette = theme ? theme.rainbow.palette : defaultTheme.palette;
+    const legend = {
+        label: palette.text.label,
+        border: palette.border.divider,
+    };
     const tooltips = {
         background: replaceAlpha(palette.getContrastText(palette.background.main), 0.8),
         color: palette.getContrastText(palette.text.main),
@@ -26,7 +31,7 @@ export default function resolveOptions(type, conditions) {
             fullWidth: true,
             labels: {
                 usePointStyle: true,
-                fontColor: palette.text.label,
+                fontColor: legend.label,
             },
         },
         tooltips: {
@@ -42,17 +47,23 @@ export default function resolveOptions(type, conditions) {
             scales: {
                 xAxes: [
                     {
+                        ticks: {
+                            fontColor: legend.label,
+                        },
                         gridLines: {
-                            color: palette.border.divider,
-                            zeroLineColor: palette.border.divider,
+                            color: legend.border,
+                            zeroLineColor: legend.border,
                         },
                     },
                 ],
                 yAxes: [
                     {
+                        ticks: {
+                            fontColor: legend.label,
+                        },
                         gridLines: {
-                            color: palette.border.divider,
-                            zeroLineColor: palette.border.divider,
+                            color: legend.border,
+                            zeroLineColor: legend.border,
                         },
                     },
                 ],
@@ -95,18 +106,24 @@ export default function resolveOptions(type, conditions) {
                 xAxes: [
                     {
                         stacked: true,
+                        ticks: {
+                            fontColor: legend.label,
+                        },
                         gridLines: {
-                            color: palette.border.divider,
-                            zeroLineColor: palette.border.divider,
+                            color: legend.border,
+                            zeroLineColor: legend.border,
                         },
                     },
                 ],
                 yAxes: [
                     {
                         stacked: true,
+                        ticks: {
+                            fontColor: legend.label,
+                        },
                         gridLines: {
-                            color: palette.border.divider,
-                            zeroLineColor: palette.border.divider,
+                            color: legend.border,
+                            zeroLineColor: legend.border,
                         },
                     },
                 ],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1378

## Changes proposed in this PR:
- feat: add theme support for `Chart` and `Dataset` components

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
