### PR TITLE
feat: add test for `attachThemeAttrs` function

### DIFF
--- a/src/styles/helpers/__test__/attachThemeAttrs.spec.js
+++ b/src/styles/helpers/__test__/attachThemeAttrs.spec.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+import { mount } from 'enzyme';
+import attachThemeAttrs from '../attachThemeAttrs';
+import defaultTheme from '../../defaultTheme';
+
+describe('attachThemeAttrs', () => {
+    let interpolatedProps = null;
+    const interpolatedFn = props => {
+        interpolatedProps = props;
+    };
+    const StyledComponent = attachThemeAttrs(styled.div)`
+        position: relative;
+        ${props => interpolatedFn(props)}
+    `;
+
+    beforeEach(() => {
+        interpolatedProps = null;
+    });
+
+    it('should return a merge object with props and default themes values when props.theme.rainbow is an empty', () => {
+        mount(<StyledComponent test />);
+        expect(interpolatedProps.test).toBe(true);
+        expect(interpolatedProps.palette).toBe(defaultTheme.palette);
+    });
+    it('should return a merge object with props and props.theme.rainbow when props.theme.rainbow was passed', () => {
+        const theme = {
+            rainbow: {
+                palette: {
+                    brand: {
+                        main: {
+                            color: 'red',
+                        },
+                    },
+                },
+            },
+        };
+        mount(<StyledComponent test theme={theme} />);
+        expect(interpolatedProps.test).toBe(true);
+        expect(interpolatedProps.palette).toBe(theme.rainbow.palette);
+    });
+});

--- a/src/styles/helpers/__test__/attachThemeAttrs.spec.js
+++ b/src/styles/helpers/__test__/attachThemeAttrs.spec.js
@@ -21,7 +21,7 @@ describe('attachThemeAttrs', () => {
     it('should return a merge object with props and default themes values when props.theme.rainbow is an empty', () => {
         mount(<StyledComponent test />);
         expect(interpolatedProps.test).toBe(true);
-        expect(interpolatedProps.palette).toBe(defaultTheme.palette);
+        expect(interpolatedProps.palette).toEqual(defaultTheme.palette);
     });
     it('should return a merge object with props and props.theme.rainbow when props.theme.rainbow was passed', () => {
         const theme = {
@@ -37,6 +37,6 @@ describe('attachThemeAttrs', () => {
         };
         mount(<StyledComponent test theme={theme} />);
         expect(interpolatedProps.test).toBe(true);
-        expect(interpolatedProps.palette).toBe(theme.rainbow.palette);
+        expect(interpolatedProps.palette).toEqual(theme.rainbow.palette);
     });
 });


### PR DESCRIPTION
fix: #1329

#### Test specs
attachThemeAttrs
- should return a merge object with props and default themes values when props.theme.rainbow is empty
- should return a merge object with props and props.theme.rainbow when props.theme.rainbow was passed

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
