### PR TITLE
fix: type inference in column props

### DIFF
--- a/src/components/Column/index.d.ts
+++ b/src/components/Column/index.d.ts
@@ -10,4 +10,4 @@ export interface ColumnProps<P> {
     type?: 'text' | 'action';
 }
 
-export default function<P>(props: ColumnProps<P>  & P): JSX.Element | null;
+export default function<P>(props: ColumnProps<P> & P): JSX.Element | null;

--- a/src/components/Column/index.d.ts
+++ b/src/components/Column/index.d.ts
@@ -10,4 +10,4 @@ export interface ColumnProps<P> {
     type?: 'text' | 'action';
 }
 
-export default function<P>(props: ColumnProps<P>): JSX.Element | null;
+export default function<P>(props: ColumnProps<P>  & P): JSX.Element | null;

--- a/src/components/Column/index.d.ts
+++ b/src/components/Column/index.d.ts
@@ -1,8 +1,8 @@
 import { ReactNode, ComponentType } from 'react';
 
-export interface ColumnProps {
+export interface ColumnProps<P> {
     header?: ReactNode;
-    component?: ComponentType;
+    component?: ComponentType<P>;
     field?: string;
     sortable?: boolean;
     width?: number | string;
@@ -10,4 +10,4 @@ export interface ColumnProps {
     type?: 'text' | 'action';
 }
 
-export default function(props: ColumnProps): JSX.Element | null;
+export default function<P>(props: ColumnProps<P>): JSX.Element | null;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1427 

## Changes proposed in this PR:
- add generics to ColumnProps

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
