### PR TITLE
fix: icons-color-on-GoogleAddressLookup-component

### DIFF
--- a/src/components/GoogleAddressLookup/icons/locationItemIcon.js
+++ b/src/components/GoogleAddressLookup/icons/locationItemIcon.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { IconCircleColor, IconPinColor } from '../styled/icons';
 
 const LocationItemIcon = props => {
     const { className } = props;
@@ -13,15 +14,16 @@ const LocationItemIcon = props => {
             xmlns="http://www.w3.org/2000/svg"
             xmlnsXlink="http://www.w3.org/1999/xlink"
         >
-            <g fill="none" fillRule="nonzero">
-                <circle fill="#e3e5ed" cx="14" cy="14" r="14" />
-                <path
-                    transform="translate(8 6)"
-                    fill="#fff"
-                    fillRule="nonzero"
-                    d="M5.383 15.677C.843 9.095 0 8.42 0 6a6 6 0 1 1 12 0c0 2.42-.843 3.095-5.383 9.677a.75.75 0 0 1-1.234 0zM6 8.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"
-                />
-            </g>
+            <IconCircleColor>
+                <circle cx="14" cy="14" r="14" />
+                <IconPinColor>
+                    <path
+                        transform="translate(8 6)"
+                        fillRule="nonzero"
+                        d="M5.383 15.677C.843 9.095 0 8.42 0 6a6 6 0 1 1 12 0c0 2.42-.843 3.095-5.383 9.677a.75.75 0 0 1-1.234 0zM6 8.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"
+                    />
+                </IconPinColor>
+            </IconCircleColor>
         </svg>
     );
 };

--- a/src/components/GoogleAddressLookup/icons/searchValueIcon.js
+++ b/src/components/GoogleAddressLookup/icons/searchValueIcon.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { SearchValueIconColor, IconPinColor } from '../styled/icons';
 
 const SearchValueIcon = props => {
     const { className } = props;
@@ -13,13 +14,15 @@ const SearchValueIcon = props => {
             xmlns="http://www.w3.org/2000/svg"
             xmlnsXlink="http://www.w3.org/1999/xlink"
         >
-            <g fill="none" fillRule="nonzero">
-                <circle fill="#01b6f5" cx="14" cy="14" r="14" />
-                <g fill="#FFF" fillRule="evenodd" transform="translate(7 7)">
-                    <path d="M7.396 7.585l.6-.601a.212.212 0 0 1 .301 0l1.38 1.38a.212.212 0 0 1 0 .301l-.6.6a.212.212 0 0 1-.3 0l-1.381-1.38a.212.212 0 0 1 0-.3z" />
-                    <path d="M4.873 0A4.466 4.466 0 0 0 .412 4.46c0 2.46 2 4.462 4.46 4.462S9.334 6.92 9.334 4.46C9.333 2 7.333 0 4.873 0zm0 .797A3.668 3.668 0 0 1 8.537 4.46a3.668 3.668 0 0 1-3.664 3.664 3.668 3.668 0 0 1-3.665-3.664A3.668 3.668 0 0 1 4.873.797zM8.333 8.973l1.052-1.051a.212.212 0 0 1 .3 0l4.036 4.036c.282.281.36.723.19 1.083a.957.957 0 0 1-1.542.268L8.333 9.273a.212.212 0 0 1 0-.3z" />
-                </g>
-            </g>
+            <SearchValueIconColor>
+                <circle cx="14" cy="14" r="14" />
+                <IconPinColor>
+                    <g fillRule="evenodd" transform="translate(7 7)">
+                        <path d="M7.396 7.585l.6-.601a.212.212 0 0 1 .301 0l1.38 1.38a.212.212 0 0 1 0 .301l-.6.6a.212.212 0 0 1-.3 0l-1.381-1.38a.212.212 0 0 1 0-.3z" />
+                        <path d="M4.873 0A4.466 4.466 0 0 0 .412 4.46c0 2.46 2 4.462 4.46 4.462S9.334 6.92 9.334 4.46C9.333 2 7.333 0 4.873 0zm0 .797A3.668 3.668 0 0 1 8.537 4.46a3.668 3.668 0 0 1-3.664 3.664 3.668 3.668 0 0 1-3.665-3.664A3.668 3.668 0 0 1 4.873.797zM8.333 8.973l1.052-1.051a.212.212 0 0 1 .3 0l4.036 4.036c.282.281.36.723.19 1.083a.957.957 0 0 1-1.542.268L8.333 9.273a.212.212 0 0 1 0-.3z" />
+                    </g>
+                </IconPinColor>
+            </SearchValueIconColor>
         </svg>
     );
 };

--- a/src/components/GoogleAddressLookup/styled/icons.js
+++ b/src/components/GoogleAddressLookup/styled/icons.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import '../../../styles/defaultTheme';
+import attachThemeAttrs from './../../../styles/helpers/attachThemeAttr';
+
+export const IconCircleColor = attachThemeAttrs(styled.svg)`
+  fill: ${props => props.palette.text.disabled}
+`;
+
+export const IconPinColor = attachThemeAttrs(styled.svg)`
+    fill: ${props => props.palette.background.main}
+`;
+
+export const SearchValueIconColor = attachThemeAttrs(styled.svg)`
+    fill: ${props => props.palette.brand.main}
+`;

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -130,7 +130,13 @@ Input.propTypes = {
     /** The id of the outer element. */
     id: PropTypes.string,
     /** A string indicating the type of autocomplete functionality.
-     * If any, to allow on the input. */
+     * If any, to allow on the input.
+     *
+     * Values accepted by the autocomplete prop: name, organization-title, username, new-password,
+     * street-address, country, cc-name, transaction-currency, language, bday, sex, url, photo,
+     * tel, email and impp
+     *
+     * For a detailed list, go to: https://www.w3.org/TR/WCAG21/#input-purposes */
     autoComplete: PropTypes.string,
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->


## Changes proposed in this PR:
-add icons.js file to the styled folder with the styles for the icons on GoogleAddressLookup component.

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
