### PR TITLE
style: picklist error border when shaded

### DIFF
--- a/src/components/Picklist/styled/input.js
+++ b/src/components/Picklist/styled/input.js
@@ -27,6 +27,14 @@ const PickerInput = attachThemeAttrs(styled(StyledInput))`
         `
         box-shadow: ${props.shadows.shadow_10};
         border: 1px solid transparent;
+        ${props.error &&
+            `
+            border: 2px solid ${props.palette.error.main};
+        `}
+        ${props.readOnly &&
+            `
+            box-shadow: none;
+        `}
     `}
 
     ${props =>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1620 

## Changes proposed in this PR:
- fix Picklist border when error and shaded is passed

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
