### PR TITLE
fix: fix isFocusable jest matcher

### DIFF
--- a/jestMatchers/toBeFocusable.js
+++ b/jestMatchers/toBeFocusable.js
@@ -1,9 +1,13 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { ForwardRef } from 'react-is';
 import { eachShouldBeOneOrFunction } from './utils';
 
 function isMountedByEnzyme(component) {
-    return typeof component.setProps === 'function'
-        && typeof component.simulate === 'function'
-        && typeof component.instance === 'function';
+    return (
+        typeof component.setProps === 'function' &&
+        typeof component.simulate === 'function' &&
+        typeof component.instance === 'function'
+    );
 }
 
 const focusables = ['button', 'input', 'select', 'textarea'];
@@ -28,16 +32,21 @@ export default function toBeFocusable(component) {
             element.simulate('focus');
         }
 
-        const instance = component.instance();
-
         const results = [
             onClickMockFn.mock.calls.length,
             onFocusMockFn.mock.calls.length,
             onBlurMockFn.mock.calls.length,
-            instance ? typeof instance.click : null,
-            instance ? typeof instance.focus : null,
-            instance ? typeof instance.blur : null,
         ];
+
+        const type = component.type();
+        if (type.$$typeof !== ForwardRef) {
+            const instance = component.instance();
+            results.push(
+                instance ? typeof instance.click : null,
+                instance ? typeof instance.focus : null,
+                instance ? typeof instance.blur : null,
+            );
+        }
 
         if (eachShouldBeOneOrFunction(results)) {
             return {
@@ -45,13 +54,15 @@ export default function toBeFocusable(component) {
                 pass: true,
             };
         }
+
         return {
             message: () => `Expected ${component.name()} to be focusable but it is not.`,
             pass: false,
         };
     }
     return {
-        message: () => 'You need to pass a component returned by mount or shallow enzyme\'s methods to check whether it is focusable or not.',
+        message: () =>
+            "You need to pass a component returned by mount or shallow enzyme's methods to check whether it is focusable or not.",
         pass: false,
     };
 }

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
         "react-codemirror2": "^6.0.0",
         "react-dom": "^16.8.6",
         "react-ga": "^2.5.3",
+        "react-is": "16.8.6",
         "react-prismic-cms": "^0.3.1",
         "react-redux": "^5.1.0",
         "react-styleguidist": "^9.2.0",

--- a/src/components/DatePicker/index.js
+++ b/src/components/DatePicker/index.js
@@ -1,7 +1,6 @@
 import React, { useRef, useImperativeHandle, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import withReduxForm from '../../libs/hocs/withReduxForm';
-import { useLocale } from '../../libs/hooks';
+import { useLocale, useReduxForm } from '../../libs/hooks';
 import { ENTER_KEY, SPACE_KEY } from '../../libs/constants';
 import CalendarIcon from './calendarIcon';
 import { useFormatDate, useDisclosure } from './hooks';
@@ -35,7 +34,7 @@ const DatePicker = React.forwardRef((props, ref) => {
         locale,
         variant,
         selectionType,
-    } = props;
+    } = useReduxForm(props);
 
     const currentLocale = useLocale(locale);
     const inputRef = useRef();
@@ -226,4 +225,4 @@ DatePicker.defaultProps = {
     variant: 'single',
 };
 
-export default withReduxForm(DatePicker);
+export default DatePicker;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12229,6 +12229,11 @@ react-icons@^3.7.0:
   dependencies:
     camelcase "^5.0.0"
 
+react-is@16.8.6, react-is@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
 react-is@^16.12.0, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -12248,11 +12253,6 @@ react-is@^16.8.1, react-is@^16.8.4:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
-
-react-is@^16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
-  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-json-view@^1.19.1:
   version "1.19.1"


### PR DESCRIPTION
…nents

<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1634 

## Changes proposed in this PR:
- fix `isFocusable` jest matcher that fail when is used on forwardRef components

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
