### PR TITLE
fix: remove undesired outline from table components headers

### DIFF
--- a/src/components/Table/head/styled/th.js
+++ b/src/components/Table/head/styled/th.js
@@ -19,6 +19,8 @@ const StyledTh = attachThemeAttrs(styled.th)`
     }
 
     :focus {
+        outline:none;
+
         .rainbow-table_header-container {
             background-color: ${props => props.palette.background.main};
             border-color: ${props => props.palette.brand.main};


### PR DESCRIPTION
Fix: #1167 

## Changes proposed in this PR:
-Added `outline:none` in Table/head/styled/th.js .focus line 22, to prevent unexpected outlines in Safari.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
