### PR TITLE
fix: tabset component with only one tab

### DIFF
--- a/src/components/Tabset/__test__/tabset.spec.js
+++ b/src/components/Tabset/__test__/tabset.spec.js
@@ -36,6 +36,15 @@ describe('<Tabset />', () => {
         );
         expect(component.find('p').text()).toBe('testing tabset');
     });
+    it('should render children with only one tab', () => {
+        const component = mount(
+            <Tabset activeTabName="tab-1">
+                <Tab label="Tab-1" name="tab-1" registerTab={registerTabMockFn} />
+            </Tabset>,
+        );
+        const item1 = component.find('Tab[name="tab-1"]').find(StyledButton);
+        expect(item1.prop('isActive')).toBe(true);
+    });
     it('should set isActive to true only on the third Tab when activeTabName is tab-3', () => {
         const component = mount(
             <Tabset activeTabName="tab-3">

--- a/src/components/Tabset/utils.js
+++ b/src/components/Tabset/utils.js
@@ -44,19 +44,15 @@ export function getChildrenTotalWidthUpToClickedTab(children, index) {
 }
 
 export function isNotSameChildren(children, prevChildren) {
-    if (!Array.isArray(children)) {
-        if (children && prevChildren) {
-            return children.props.name !== prevChildren.props.name;
-        }
-        return false;
+    if (Array.isArray(children)) {
+        return children.some((child, index) => {
+            if (child && prevChildren[index]) {
+                return child.props.name !== prevChildren[index].props.name;
+            }
+            return false;
+        });
     }
-
-    return children.some((child, index) => {
-        if (child && prevChildren[index]) {
-            return child.props.name !== prevChildren[index].props.name;
-        }
-        return false;
-    });
+    return children.props.name !== prevChildren.props.name;
 }
 
 export function getUpdatedTabsetChildren(tabsetChildren, tab, nameToUpdate) {

--- a/src/components/Tabset/utils.js
+++ b/src/components/Tabset/utils.js
@@ -44,6 +44,13 @@ export function getChildrenTotalWidthUpToClickedTab(children, index) {
 }
 
 export function isNotSameChildren(children, prevChildren) {
+    if (!Array.isArray(children)) {
+        if (children && prevChildren) {
+            return children.props.name !== prevChildren.props.name;
+        }
+        return false;
+    }
+
     return children.some((child, index) => {
         if (child && prevChildren[index]) {
             return child.props.name !== prevChildren[index].props.name;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->
### fix: tabset component with only one tab

fix: #1667 

## Changes proposed in this PR:
- The problem was at the function "IsNotSameChildren" at utils.js (Tabset component). This function is expecting an array of objects but when a single tab is given the parameter that receives that function is an object. So, method ".some" is available for arrays but when an object is received an error occurs.
- A new check was added to make the proper comparation

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
