### PR TITLE
fix: [Fixed Header table when using iOS]

### DIFF
--- a/src/components/Table/head/styled/headerContainer.js
+++ b/src/components/Table/head/styled/headerContainer.js
@@ -2,10 +2,13 @@ import styled from 'styled-components';
 import { PADDING_X_SMALL } from '../../../../styles/paddings';
 
 const StyledHeaderContainer = styled.div`
+    padding: 0 0 40px 0;
     border: 1px transparent solid;
+    padding: 0 0 40px 0;
     display: flex;
     align-items: center;
     height: 44px;
+    position: relative;
     padding: 0 ${PADDING_X_SMALL};
 `;
 

--- a/src/components/Table/styled/scrollableY.js
+++ b/src/components/Table/styled/scrollableY.js
@@ -2,10 +2,12 @@ import styled from 'styled-components';
 import attachThemeAttrs from '../../../styles/helpers/attachThemeAttrs';
 
 const StyledScrollableY = attachThemeAttrs(styled.div)`
-    height: 100%;
-    overflow: hidden;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
+padding: 0 0 40px 0;
+height: 100%;
+overflow: hidden;
+overflow-y: scroll;
+position:relative;
+-webkit-overflow-scrolling: touch;
     border-top: 1px solid ${props => props.palette.border.divider};
     background-color: ${props => props.palette.background.main};
     ${props =>


### PR DESCRIPTION
fix: [Fixed Header table when using iOS]  #700
 fix: #700 
Changes proposed in this PR:
The problem was the position of the table component Scrollable Y. I added a relative position, that makes the header scrollable 

 I have followed (at least) the PR section of the contributing guide.

@nexxtway/react-rainbow
