### PR TITLE
feat: add `success`, `error` and `warning` variants to the Chip compo…

### DIFF
--- a/src/components/Chip/index.js
+++ b/src/components/Chip/index.js
@@ -35,8 +35,16 @@ Chip.propTypes = {
     /** Displays tooltip text when the mouse moves over the element. */
     title: PropTypes.string,
     /** The variant changes the appearance of the Chip. Accepted variants include base,
-     * neutral, outline-brand and brand. This value defaults to base. */
-    variant: PropTypes.oneOf(['base', 'neutral', 'outline-brand', 'brand']),
+     * neutral, outline-brand, brand, success, warning and error. This value defaults to base. */
+    variant: PropTypes.oneOf([
+        'base',
+        'neutral',
+        'outline-brand',
+        'brand',
+        'success',
+        'warning',
+        'error',
+    ]),
     /** The action triggered when the close button is clicked. */
     onDelete: PropTypes.func,
     /** A CSS class for the outer element, in addition to the component's base classes. */

--- a/src/components/Chip/readme.md
+++ b/src/components/Chip/readme.md
@@ -9,9 +9,15 @@ import { Chip } from 'react-rainbow-components';
 
     <Chip className="rainbow-m-around_medium" label="Chip Neutral" variant="neutral" />
 
-    <Chip className="rainbow-m-around_medium" label="Chip Neutral" variant="outline-brand" />
+    <Chip className="rainbow-m-around_medium" label="Chip Outline Brand" variant="outline-brand" />
 
     <Chip className="rainbow-m-around_medium" label="Chip Brand" variant="brand" />
+
+    <Chip className="rainbow-m-around_medium" label="Chip Success" variant="success" />
+
+    <Chip className="rainbow-m-around_medium" label="Chip Warning" variant="warning" />
+
+    <Chip className="rainbow-m-around_medium" label="Chip Error" variant="error" />
 </div>
 ```
 
@@ -48,6 +54,27 @@ import { Chip } from 'react-rainbow-components';
         variant="brand"
         onDelete={() => alert('Delete Chip!')}
     />
+
+    <Chip
+        className="rainbow-m-around_medium"
+        label="Chip Success"
+        variant="success"
+        onDelete={() => alert('Delete Chip!')}
+    />
+
+    <Chip
+        className="rainbow-m-around_medium"
+        label="Chip Warning"
+        variant="warning"
+        onDelete={() => alert('Delete Chip!')}
+    />
+
+    <Chip
+        className="rainbow-m-around_medium"
+        label="Chip Error"
+        variant="error"
+        onDelete={() => alert('Delete Chip!')}
+    />
 </div>
 ```
 
@@ -69,13 +96,15 @@ const ChipContainer = {
     paddingLeft: 0,
 };
 
+const variants = ['brand', 'success', 'warning', 'error'];
+
 const Icon = styled.span.attrs(props => {
     return props.theme.rainbow.palette;
 })`
     ${props =>
-        props.variant === 'brand' &&
+        variants.includes(props.variant) &&
         `
-            color: ${props.getContrastText(props.brand.main)};
+            color: ${props.getContrastText(props[props.variant].main)};
         `};
     ${props =>
         props.variant === 'outline-brand' &&
@@ -148,6 +177,49 @@ const Icon = styled.span.attrs(props => {
                     className="rainbow-m-right_xx-small"
                 />{' '}
                 Chip Brand{' '}
+            </Icon>
+        }
+    />
+
+    <Chip
+        className="rainbow-m-around_medium"
+        variant="success"
+        label={
+            <Icon variant="success">
+                <FontAwesomeIcon
+                    icon={faStar}
+                    className="rainbow-m-right_xx-small"
+                />{' '}
+                Chip Success{' '}
+            </Icon>
+        }
+    />
+
+    <Chip
+        className="rainbow-m-around_medium"
+        variant="warning"
+        onDelete={() => alert('Delete Chip!')}
+        label={
+            <Icon variant="warning">
+                <FontAwesomeIcon
+                    icon={faStar}
+                    className="rainbow-m-right_xx-small"
+                />{' '}
+                Chip Warning{' '}
+            </Icon>
+        }
+    />
+
+    <Chip
+        className="rainbow-m-around_medium"
+        variant="error"
+        label={
+            <Icon variant="error">
+                <FontAwesomeIcon
+                    icon={faStar}
+                    className="rainbow-m-right_xx-small"
+                />{' '}
+                Chip Error{' '}
             </Icon>
         }
     />

--- a/src/components/Chip/styled/buttonIcon.js
+++ b/src/components/Chip/styled/buttonIcon.js
@@ -3,6 +3,7 @@ import attachThemeAttrs from '../../../styles/helpers/attachThemeAttrs';
 import ButtonIcon from '../../ButtonIcon';
 import { MARGIN_XX_SMALL } from '../../../styles/margins';
 
+const variants = ['brand', 'success', 'warning', 'error'];
 const StyledButtonIcon = attachThemeAttrs(styled(ButtonIcon))`
     margin-right: -0.6rem;
     margin-left: ${MARGIN_XX_SMALL};
@@ -10,8 +11,8 @@ const StyledButtonIcon = attachThemeAttrs(styled(ButtonIcon))`
     flex-shrink: 0;
     ${props => props.variant === 'outline-brand' && `fill: ${props.palette.brand.main};`};
     ${props =>
-        props.variant === 'brand' &&
-        `fill: ${props.palette.getContrastText(props.palette.brand.main)};`};
+        variants.includes(props.variant) &&
+        `fill: ${props.palette.getContrastText(props.palette[props.variant].main)};`};
 `;
 
 export default StyledButtonIcon;

--- a/src/components/Chip/styled/container.js
+++ b/src/components/Chip/styled/container.js
@@ -42,6 +42,27 @@ const StyledContainer = attachThemeAttrs(styled.span)`
             border: 1px solid ${props.palette.brand.main};
             color: ${props.palette.getContrastText(props.palette.brand.main)};
         `};
+    ${props =>
+        props.variant === 'success' &&
+        `
+            background-color: ${props.palette.success.main};
+            border: 1px solid ${props.palette.success.main};
+            color: ${props.palette.getContrastText(props.palette.success.main)};
+        `};
+    ${props =>
+        props.variant === 'warning' &&
+        `
+            background-color: ${props.palette.warning.main};
+            border: 1px solid ${props.palette.warning.main};
+            color: ${props.palette.getContrastText(props.palette.warning.main)};
+        `};
+    ${props =>
+        props.variant === 'error' &&
+        `
+            background-color: ${props.palette.error.main};
+            border: 1px solid ${props.palette.error.main};
+            color: ${props.palette.getContrastText(props.palette.error.main)};
+        `};
 `;
 
 export default StyledContainer;

--- a/src/components/Chip/styled/container.js
+++ b/src/components/Chip/styled/container.js
@@ -4,6 +4,7 @@ import { BORDER_RADIUS_2 } from '../../../styles/borderRadius';
 import { PADDING_SMALL } from '../../../styles/paddings';
 import { FONT_SIZE_TEXT_MEDIUM } from '../../../styles/fontSizes';
 
+const variants = ['brand', 'success', 'warning', 'error'];
 const StyledContainer = attachThemeAttrs(styled.span)`
     display: inline-flex;
     align-items: center;
@@ -36,32 +37,11 @@ const StyledContainer = attachThemeAttrs(styled.span)`
             color: ${props.palette.brand.main};
         `};
     ${props =>
-        props.variant === 'brand' &&
+        variants.includes(props.variant) &&
         `
-            background-color: ${props.palette.brand.main};
-            border: 1px solid ${props.palette.brand.main};
-            color: ${props.palette.getContrastText(props.palette.brand.main)};
-        `};
-    ${props =>
-        props.variant === 'success' &&
-        `
-            background-color: ${props.palette.success.main};
-            border: 1px solid ${props.palette.success.main};
-            color: ${props.palette.getContrastText(props.palette.success.main)};
-        `};
-    ${props =>
-        props.variant === 'warning' &&
-        `
-            background-color: ${props.palette.warning.main};
-            border: 1px solid ${props.palette.warning.main};
-            color: ${props.palette.getContrastText(props.palette.warning.main)};
-        `};
-    ${props =>
-        props.variant === 'error' &&
-        `
-            background-color: ${props.palette.error.main};
-            border: 1px solid ${props.palette.error.main};
-            color: ${props.palette.getContrastText(props.palette.error.main)};
+            background-color: ${props.palette[props.variant].main};
+            border: 1px solid ${props.palette[props.variant].main};
+            color: ${props.palette.getContrastText(props.palette[props.variant].main)};
         `};
 `;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1713

## Changes proposed in this PR:
- add `success`, `error` and `warning` variants to the Chip component 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
