### PR TITLE
fix: reset the selection on the Calendar when clicking in a day inside the selected range

### DIFF
--- a/src/components/Calendar/helpers/__test__/buildNewRangeFromValue.spec.js
+++ b/src/components/Calendar/helpers/__test__/buildNewRangeFromValue.spec.js
@@ -18,13 +18,21 @@ describe('buildNewRangeFromValue', () => {
             range: [date1, date2],
         });
     });
-    it('should return array with single date equal to date3', () => {
+    it('should return array with single date equal to value when value is outside range', () => {
         const date1 = new Date(2019, 0, 2);
         const date2 = new Date(2019, 0, 21, 23, 59, 59, 999);
         const date3 = new Date(2019, 0, 15);
         const range = [date1, date2];
         expect(buildNewRangeFromValue(date3, range)).toEqual({
             range: [date3],
+        });
+    });
+    it('should return array with single date equal to value when only range start is specified and value is before', () => {
+        const date1 = new Date(2019, 0, 2);
+        const date3 = new Date(2019, 0, 15);
+        const range = [date3];
+        expect(buildNewRangeFromValue(date1, range)).toEqual({
+            range: [date1],
         });
     });
 });

--- a/src/components/Calendar/helpers/__test__/buildNewRangeFromValue.spec.js
+++ b/src/components/Calendar/helpers/__test__/buildNewRangeFromValue.spec.js
@@ -18,14 +18,13 @@ describe('buildNewRangeFromValue', () => {
             range: [date1, date2],
         });
     });
-    it('should return array with two dates and date3 as first date', () => {
+    it('should return array with single date equal to date3', () => {
         const date1 = new Date(2019, 0, 2);
         const date2 = new Date(2019, 0, 21, 23, 59, 59, 999);
         const date3 = new Date(2019, 0, 15);
         const range = [date1, date2];
         expect(buildNewRangeFromValue(date3, range)).toEqual({
-            range: [date3, date2],
-            nextUpdatePosition: 1,
+            range: [date3],
         });
     });
 });

--- a/src/components/Calendar/helpers/buildNewRangeFromValue.js
+++ b/src/components/Calendar/helpers/buildNewRangeFromValue.js
@@ -1,29 +1,10 @@
-import isDateWithinRange from './isDateWithinRange';
-import compareDates from './compareDates';
-
-export default function buildNewRangeFromValue(value, currentRange, currentUpdatePosition = 0) {
+export default function buildNewRangeFromValue(value, currentRange) {
     if (currentRange && currentRange.length > 0) {
         const [rangeStart, rangeEnd] = currentRange;
         const newRangeStart = new Date(rangeStart);
         newRangeStart.setHours(0, 0, 0, 0);
 
-        if (rangeEnd && isDateWithinRange(value, currentRange)) {
-            if (currentUpdatePosition === 0) {
-                value.setHours(0, 0, 0, 0);
-                const newRangeEnd = new Date(rangeEnd);
-                newRangeEnd.setHours(23, 59, 59, 999);
-                return {
-                    range: [value, newRangeEnd],
-                    nextUpdatePosition: 1,
-                };
-            }
-
-            value.setHours(23, 59, 59, 999);
-            return {
-                range: [newRangeStart, value],
-                nextUpdatePosition: 0,
-            };
-        } else if (!rangeEnd && compareDates(value, newRangeStart) >= 0) {
+        if (!rangeEnd) {
             value.setHours(23, 59, 59, 999);
             return {
                 range: [newRangeStart, value],

--- a/src/components/Calendar/helpers/buildNewRangeFromValue.js
+++ b/src/components/Calendar/helpers/buildNewRangeFromValue.js
@@ -1,3 +1,5 @@
+import compareDates from './compareDates';
+
 export default function buildNewRangeFromValue(value, currentRange) {
     if (currentRange && currentRange.length > 0) {
         const [rangeStart, rangeEnd] = currentRange;
@@ -5,6 +7,13 @@ export default function buildNewRangeFromValue(value, currentRange) {
         newRangeStart.setHours(0, 0, 0, 0);
 
         if (!rangeEnd) {
+            if (compareDates(value, newRangeStart) <= 0) {
+                value.setHours(0, 0, 0, 0);
+                return {
+                    range: [value],
+                };
+            }
+
             value.setHours(23, 59, 59, 999);
             return {
                 range: [newRangeStart, value],

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useLocale } from '../../libs/hooks';
 import SingleCalendar from './singleCalendar';
@@ -12,19 +12,16 @@ import { useCurrentDateFromValue, useRangeFromValue } from './hooks';
 export default function Calendar(props) {
     const { locale, selectionType, variant, value, onChange, ...rest } = props;
     const currentLocale = useLocale(locale);
-    const [currentRangeUpdatePosition, setCurrentRangeUpdatePosition] = useState(0);
     const currentValue = useCurrentDateFromValue(value);
     const range = useRangeFromValue(value, selectionType);
 
     const handleChange = useCallback(
         newValue => {
             if (selectionType === 'single') return onChange(newValue);
-            const result = buildNewRangeFromValue(newValue, range, currentRangeUpdatePosition);
-            if (Number.isInteger(result.nextUpdatePosition))
-                setCurrentRangeUpdatePosition(result.nextUpdatePosition);
+            const result = buildNewRangeFromValue(newValue, range);
             return onChange(result.range);
         },
-        [selectionType, onChange, range, currentRangeUpdatePosition],
+        [selectionType, onChange, range],
     );
 
     if (variant === 'double')


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1716 

## Changes proposed in this PR:
- fix the selection reset on the Calendar when clicking in a day inside the selected range

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
