### PR TITLE
test: add test when copy and paste on the PhoneInput component to accept only number

### DIFF
--- a/src/components/PhoneInput/__tests__/phoneinput.spec.js
+++ b/src/components/PhoneInput/__tests__/phoneinput.spec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import PhoneInput from '../';
+
+const Wrapper = () => {
+    const [value, setValue] = React.useState('');
+    return (
+        <PhoneInput
+            label="Phone Number"
+            value={value}
+            onChange={setValue}
+            placeholder="Enter your phone number"
+        />
+    );
+};
+
+describe('<PhoneInput />', () => {
+    it('Should accept only numbers.', () => {
+        const wrapper = mount(<Wrapper />);
+        wrapper
+            .find('input[type="tel"]')
+            .first()
+            .simulate('change', { target: { value: 'Your phone number is 0987256983' } });
+        wrapper.update();
+        expect(wrapper.find('input[type="tel"]').prop('value')).toBe('0987256983');
+    });
+});

--- a/src/components/PhoneInput/__tests__/phoneinput.spec.js
+++ b/src/components/PhoneInput/__tests__/phoneinput.spec.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import PhoneInput from '../';
 
 describe('<PhoneInput />', () => {
-    it('Should accept only numbers.', () => {
+    it('should accept only numbers.', () => {
         const onChangeMockFn = jest.fn();
         const wrapper = mount(<PhoneInput label="Phone Number" onChange={onChangeMockFn} />);
 

--- a/src/components/PhoneInput/__tests__/phoneinput.spec.js
+++ b/src/components/PhoneInput/__tests__/phoneinput.spec.js
@@ -2,26 +2,21 @@ import React from 'react';
 import { mount } from 'enzyme';
 import PhoneInput from '../';
 
-const Wrapper = () => {
-    const [value, setValue] = React.useState('');
-    return (
-        <PhoneInput
-            label="Phone Number"
-            value={value}
-            onChange={setValue}
-            placeholder="Enter your phone number"
-        />
-    );
-};
-
 describe('<PhoneInput />', () => {
     it('Should accept only numbers.', () => {
-        const wrapper = mount(<Wrapper />);
+        const onChangeMockFn = jest.fn();
+        const wrapper = mount(<PhoneInput label="Phone Number" onChange={onChangeMockFn} />);
+
         wrapper
             .find('input[type="tel"]')
             .first()
             .simulate('change', { target: { value: 'Your phone number is 0987256983' } });
         wrapper.update();
-        expect(wrapper.find('input[type="tel"]').prop('value')).toBe('0987256983');
+
+        expect(onChangeMockFn).toHaveBeenCalledWith(
+            expect.objectContaining({
+                phone: '0987256983',
+            }),
+        );
     });
 });

--- a/src/components/PhoneInput/countriesDropdown/hooks/useKeyboardNavigation.js
+++ b/src/components/PhoneInput/countriesDropdown/hooks/useKeyboardNavigation.js
@@ -84,7 +84,9 @@ export default function useKeyboardNavigation(
 
     useEffect(() => {
         handleActiveChange(0);
-        scrollableRef.current.scrollTo(0, 0);
+        if (scrollableRef.current && scrollableRef.current.scrollTo) {
+            scrollableRef.current.scrollTo(0, 0);
+        }
         activeIndex.current = 0;
     }, [country, handleActiveChange, itemsRef, length, scrollableRef]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1679 

## Changes proposed in this PR:
- test: add test when copy and paste on the PhoneInput component to accept only number

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow

