### PR TITLE
fix: fixing children limitation on renderif component using ract frag…

### DIFF
--- a/src/components/RenderIf/index.js
+++ b/src/components/RenderIf/index.js
@@ -1,8 +1,9 @@
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 export default function RenderIf({ isTrue, children }) {
     if (isTrue) {
-        return children;
+        return <Fragment>{children}</Fragment>;
     }
     return null;
 }


### PR DESCRIPTION
- Wrapped children with react fragments.

- Now the developer doesn't need to wrap the multiple children inside fragments every time RenderIf is used

<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1758 

## Changes proposed in this PR:
-

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
