### PR TITLE
fix: make the MultiSelect header fixed when scrolling

### DIFF
--- a/src/components/InternalDropdown/placeholderOption.js
+++ b/src/components/InternalDropdown/placeholderOption.js
@@ -1,17 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import StyledHeader from '../Option/styled/header';
 import StyledHeaderLabel from '../Option/styled/headerLabel';
-import { StyledPrimitiveCheckbox } from './styled';
+import { StyledPrimitiveCheckbox, StyledTopHeader } from './styled';
 
 function PlaceholderOption(props) {
     const { label, title, isChecked, onClick, ...rest } = props;
 
     return (
-        <StyledHeader title={title} role="presentation" onMouseDown={onClick}>
+        <StyledTopHeader title={title} role="presentation" onMouseDown={onClick}>
             <StyledPrimitiveCheckbox type="checkbox" label="" checked={isChecked} {...rest} />
             <StyledHeaderLabel>{label}</StyledHeaderLabel>
-        </StyledHeader>
+        </StyledTopHeader>
     );
 }
 

--- a/src/components/InternalDropdown/styled/index.js
+++ b/src/components/InternalDropdown/styled/index.js
@@ -3,6 +3,7 @@ import attachThemeAttrs from '../../../styles/helpers/attachThemeAttrs';
 import { FONT_SIZE_TEXT_LARGE } from '../../../styles/fontSizes';
 import SearchIcon from '../icons/searchIcon';
 import PrimitiveCheckbox from '../../PrimitiveCheckbox';
+import StyledHeader from '../../Option/styled/header';
 
 export const Dropdown = attachThemeAttrs(styled.div)`
     position: relative;
@@ -158,4 +159,11 @@ export const StyledPrimitiveCheckbox = styled(PrimitiveCheckbox)`
     margin-bottom: 0;
     margin-left: 4px;
     margin-right: 8px;
+`;
+
+export const StyledTopHeader = attachThemeAttrs(styled(StyledHeader))`
+    position: sticky;
+    top: 0;
+    background: ${props => props.palette.background.main};
+    z-index: 1;
 `;


### PR DESCRIPTION
fix: #1778 

## Changes proposed in this PR:
- Make MultiSelect header fixed when scrolling

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
