### PR TITLE
feat: add delimiter between placeholder and options in MultiSelect co…

### DIFF
--- a/src/components/InternalDropdown/styled/index.js
+++ b/src/components/InternalDropdown/styled/index.js
@@ -156,7 +156,6 @@ export const MessageHighLight = attachThemeAttrs(styled.p)`
 
 export const StyledPrimitiveCheckbox = styled(PrimitiveCheckbox)`
     display: inline;
-    margin-bottom: 0;
     margin-left: 4px;
     margin-right: 8px;
 `;
@@ -164,6 +163,7 @@ export const StyledPrimitiveCheckbox = styled(PrimitiveCheckbox)`
 export const StyledTopHeader = attachThemeAttrs(styled(StyledHeader))`
     position: sticky;
     top: 0;
+    border-bottom: 1px solid ${props => props.palette.border.divider};
     background: ${props => props.palette.background.main};
     z-index: 1;
 `;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1797

## Changes proposed in this PR:
- add delimiter between placeholder and options in MultiSelect component
- remove an unnecessary property in styles

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
