### PR TITLE
feat: add min and max props to the Input component

### DIFF
--- a/src/components/Input/index.d.ts
+++ b/src/components/Input/index.d.ts
@@ -35,6 +35,8 @@ export interface InputProps extends BaseProps {
     placeholder?: string;
     icon?: ReactNode;
     iconPosition?: IconPosition;
+    max?: number | string;
+    min?: number | string;
     maxLength?: number;
     minLength?: number;
     bottomHelpText?: ReactNode;

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -87,6 +87,10 @@ Input.propTypes = {
     /** Describes the position of the icon with respect to body. Options include left and right.
      * This value defaults to left. */
     iconPosition: PropTypes.oneOf(['left', 'right']),
+    /** Specifies the minimum value allowed in the field. */
+    max: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    /** Specifies the maximum value allowed in the field. */
+    min: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     /** The maximum number of characters allowed in the field. */
     maxLength: PropTypes.number,
     /** The minimum number of characters allowed in the field. */
@@ -150,6 +154,8 @@ Input.defaultProps = {
     placeholder: null,
     icon: undefined,
     iconPosition: 'left',
+    max: undefined,
+    min: undefined,
     maxLength: undefined,
     minLength: undefined,
     bottomHelpText: null,

--- a/src/components/Input/inputBase/__test__/input.spec.js
+++ b/src/components/Input/inputBase/__test__/input.spec.js
@@ -42,6 +42,14 @@ describe('<InputBase/>', () => {
         const component = mount(<InputBase required />);
         expect(component.find('input').prop('required')).toBe(true);
     });
+    it('should set the max passed in the Input element', () => {
+        const component = mount(<InputBase max={5} />);
+        expect(component.find('input').prop('max')).toBe(5);
+    });
+    it('should set the min passed in the Input element', () => {
+        const component = mount(<InputBase min={1} />);
+        expect(component.find('input').prop('min')).toBe(1);
+    });
     it('should set the maxLength passed in the Input element', () => {
         const component = mount(<InputBase maxLength={0} />);
         expect(component.find('input').prop('maxLength')).toBe(0);

--- a/src/components/Input/inputBase/index.js
+++ b/src/components/Input/inputBase/index.js
@@ -76,6 +76,8 @@ export default class InputBase extends Component {
             onClick,
             onKeyDown,
             type,
+            max,
+            min,
             maxLength,
             minLength,
             pattern,
@@ -130,6 +132,8 @@ export default class InputBase extends Component {
                         disabled={disabled}
                         readOnly={readOnly}
                         required={required}
+                        max={max}
+                        min={min}
                         maxLength={maxLength}
                         minLength={minLength}
                         pattern={pattern}
@@ -181,6 +185,8 @@ InputBase.propTypes = {
     placeholder: PropTypes.string,
     icon: PropTypes.node,
     iconPosition: PropTypes.oneOf(['left', 'right']),
+    max: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    min: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     maxLength: PropTypes.number,
     minLength: PropTypes.number,
     bottomHelpText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
@@ -213,6 +219,8 @@ InputBase.defaultProps = {
     placeholder: undefined,
     icon: undefined,
     iconPosition: 'left',
+    max: undefined,
+    min: undefined,
     maxLength: undefined,
     minLength: undefined,
     bottomHelpText: null,

--- a/src/components/Input/readme.md
+++ b/src/components/Input/readme.md
@@ -391,3 +391,36 @@ const inputStyles = {
     />
 </div>
 ```
+
+##### input with range
+
+```js
+import React from 'react';
+import { Input } from 'react-rainbow-components';
+
+const inputStyles = {
+    width: 300,
+};
+
+<div className="rainbow-align-content_center rainbow-p-vertical_x-large rainbow-flex_wrap">
+    <Input
+        className="rainbow-p-around_medium"
+        style={inputStyles}
+        label="Input Number"
+        bottomHelpText="between 10 & 100"
+        placeholder="1234567890"
+        type="number"
+        max={100}
+        min={10}
+    />
+    <Input
+        className="rainbow-p-around_medium"
+        style={inputStyles}
+        label="Input Date"
+        bottomHelpText="between 2019-01-01 & 2021-01-01"
+        type="date"
+        max="2021-01-01"
+        min="2019-01-01"
+    />
+</div>
+```


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1822

## Changes proposed in this PR:
- add "min" and "max" props to the Input component
- add tests
- add interactive example

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
