### PR TITLE
fix: remove unnecessary imports in FileSelector component examples

### DIFF
--- a/src/components/FileSelector/readme.md
+++ b/src/components/FileSelector/readme.md
@@ -8,7 +8,7 @@ const containerStyles = {
     maxWidth: 300,
 };
 
-function FileSelectorExample(props) {
+function FileSelectorExample() {
     const [files, setFiles] = useState([]);
 
     const handleChange = files => {
@@ -42,7 +42,7 @@ const containerStyles = {
     maxWidth: 300,
 };
 
-function FileSelectorExample(props) {
+function FileSelectorExample() {
     const [files, setFiles] = useState([]);
 
     const handleChange = files => {
@@ -76,7 +76,7 @@ const containerStyles = {
     maxWidth: 300,
 };
 
-function FileSelectorExample(props) {
+function FileSelectorExample() {
     const [files, setFiles] = useState([]);
 
     const handleChange = files => {
@@ -109,7 +109,7 @@ const containerStyles = {
     maxWidth: 300,
 };
 
-function FileSelectorExample(props) {
+function FileSelectorExample() {
     const [files, setFiles] = useState([]);
 
     const handleChange = files => {
@@ -142,7 +142,7 @@ const containerStyles = {
     maxWidth: 300,
 };
 
-function FileSelectorExample(props) {
+function FileSelectorExample() {
     const [files, setFiles] = useState([]);
 
     const handleChange = files => {
@@ -177,7 +177,7 @@ const containerStyles = {
     maxWidth: 300,
 };
 
-function FileSelectorExample(props) {
+function FileSelectorExample() {
     const [files, setFiles] = useState([]);
 
     const handleChange = files => {
@@ -212,7 +212,7 @@ const containerStyles = {
     maxWidth: 300,
 };
 
-function FileSelectorExample(props) {
+function FileSelectorExample() {
     const [files, setFiles] = useState([]);
 
     const handleChange = files => {
@@ -246,7 +246,7 @@ const containerStyles = {
     maxWidth: 300,
 };
 
-function FileSelectorExample(props) {
+function FileSelectorExample() {
     const [files, setFiles] = useState([]);
 
     const handleChange = files => {
@@ -280,7 +280,7 @@ const containerStyles = {
     maxWidth: 300,
 };
 
-function FileSelectorExample(props) {
+function FileSelectorExample() {
     const [files, setFiles] = useState([]);
 
     const handleChange = files => {
@@ -317,7 +317,7 @@ const containerStyles = {
     maxWidth: 300,
 };
 
-function FileSelectorExample(props) {
+function FileSelectorExample() {
     const [files, setFiles] = useState([]);
 
     const handleChange = files => {

--- a/src/components/FileSelector/readme.md
+++ b/src/components/FileSelector/readme.md
@@ -3,8 +3,6 @@
 ```js
 import React, { useState } from 'react';
 import { FileSelector } from 'react-rainbow-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload } from '@fortawesome/free-solid-svg-icons';
 
 const containerStyles = {
     maxWidth: 300,
@@ -39,8 +37,6 @@ function FileSelectorExample(props) {
 ```js
 import React, { useState } from 'react';
 import { FileSelector } from 'react-rainbow-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload } from '@fortawesome/free-solid-svg-icons';
 
 const containerStyles = {
     maxWidth: 300,
@@ -70,14 +66,11 @@ function FileSelectorExample(props) {
 <FileSelectorExample />
 ```
 
-
 ##### FileSelector inline disabled
 
 ```js
 import React, { useState } from 'react';
 import { FileSelector } from 'react-rainbow-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload } from '@fortawesome/free-solid-svg-icons';
 
 const containerStyles = {
     maxWidth: 300,
@@ -106,14 +99,11 @@ function FileSelectorExample(props) {
 <FileSelectorExample />
 ```
 
-
 ##### FileSelector inline with error
 
 ```js
 import React, { useState } from 'react';
 import { FileSelector } from 'react-rainbow-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload } from '@fortawesome/free-solid-svg-icons';
 
 const containerStyles = {
     maxWidth: 300,
@@ -147,8 +137,6 @@ function FileSelectorExample(props) {
 ```js
 import React, { useState } from 'react';
 import { FileSelector } from 'react-rainbow-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload } from '@fortawesome/free-solid-svg-icons';
 
 const containerStyles = {
     maxWidth: 300,
@@ -184,8 +172,6 @@ function FileSelectorExample(props) {
 ```js
 import React, { useState } from 'react';
 import { FileSelector } from 'react-rainbow-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload } from '@fortawesome/free-solid-svg-icons';
 
 const containerStyles = {
     maxWidth: 300,
@@ -221,8 +207,6 @@ function FileSelectorExample(props) {
 ```js
 import React, { useState } from 'react';
 import { FileSelector } from 'react-rainbow-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload } from '@fortawesome/free-solid-svg-icons';
 
 const containerStyles = {
     maxWidth: 300,
@@ -252,14 +236,11 @@ function FileSelectorExample(props) {
 <FileSelectorExample />
 ```
 
-
 ##### FileSelector multiline with error
 
 ```js
 import React, { useState } from 'react';
 import { FileSelector } from 'react-rainbow-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload } from '@fortawesome/free-solid-svg-icons';
 
 const containerStyles = {
     maxWidth: 300,
@@ -294,8 +275,6 @@ function FileSelectorExample(props) {
 ```js
 import React, { useState } from 'react';
 import { FileSelector } from 'react-rainbow-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload } from '@fortawesome/free-solid-svg-icons';
 
 const containerStyles = {
     maxWidth: 300,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

## Changes proposed in this PR:
- remove unnecessary imports in examples
- fix indentation problem in examples

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
