### PR TITLE
feat: add `orientation` prop on the `RadioGroup` and `CheckboxGroup` components

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
         "autosize": "^4.0.2",
         "chart.js": "2.7.3",
         "clipboard-copy": "^2.0.0",
-        "core-js": "^3.6.5",
         "prop-types": "^15.6.2",
         "react-async-script-loader": "^0.3.0",
         "rehype-highlight": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "autosize": "^4.0.2",
         "chart.js": "2.7.3",
         "clipboard-copy": "^2.0.0",
+        "core-js": "^3.6.5",
         "prop-types": "^15.6.2",
         "react-async-script-loader": "^0.3.0",
         "rehype-highlight": "^4.0.0",

--- a/src/components/CheckboxGroup/__test__/checkboxGroup.spec.js
+++ b/src/components/CheckboxGroup/__test__/checkboxGroup.spec.js
@@ -30,7 +30,7 @@ describe('<CheckboxGroup />', () => {
         );
     });
 
-    it('renders correctly in vertical orientation (implicit)', () => {
+    it('renders correctly in vertical orientation (explicit)', () => {
         const options = [{ value: 'admin', label: 'Admin' }, { value: 'user', label: 'User' }];
 
         const component = mount(<CheckboxGroup options={options} orientation="vertical" />);
@@ -41,7 +41,7 @@ describe('<CheckboxGroup />', () => {
         );
     });
 
-    it('renders correctly in horizontal orientation (implicit)', () => {
+    it('renders correctly in horizontal orientation (explicit)', () => {
         const options = [{ value: 'admin', label: 'Admin' }, { value: 'user', label: 'User' }];
 
         const component = mount(<CheckboxGroup options={options} orientation="horizontal" />);

--- a/src/components/CheckboxGroup/__test__/checkboxGroup.spec.js
+++ b/src/components/CheckboxGroup/__test__/checkboxGroup.spec.js
@@ -18,4 +18,35 @@ describe('<CheckboxGroup />', () => {
         const checkbox = component.find('CheckboxList');
         expect(checkbox.prop('values')).toEqual(['admin', 'user-1']);
     });
+
+    it('renders correctly in vertical orientation (default)', () => {
+        const options = [{ value: 'admin', label: 'Admin' }, { value: 'user', label: 'User' }];
+
+        const component = mount(<CheckboxGroup options={options} />);
+        const elem = component.find('CheckboxGroupStyledContentContainer');
+
+        expect(getComputedStyle(elem.getDOMNode()).getPropertyValue('flex-direction')).toBe(
+            'column',
+        );
+    });
+
+    it('renders correctly in vertical orientation (implicit)', () => {
+        const options = [{ value: 'admin', label: 'Admin' }, { value: 'user', label: 'User' }];
+
+        const component = mount(<CheckboxGroup options={options} orientation="vertical" />);
+        const elem = component.find('CheckboxGroupStyledContentContainer');
+
+        expect(getComputedStyle(elem.getDOMNode()).getPropertyValue('flex-direction')).toBe(
+            'column',
+        );
+    });
+
+    it('renders correctly in horizontal orientation (implicit)', () => {
+        const options = [{ value: 'admin', label: 'Admin' }, { value: 'user', label: 'User' }];
+
+        const component = mount(<CheckboxGroup options={options} orientation="horizontal" />);
+        const elem = component.find('CheckboxGroupStyledContentContainer');
+
+        expect(getComputedStyle(elem.getDOMNode()).getPropertyValue('flex-direction')).toBe('row');
+    });
 });

--- a/src/components/CheckboxGroup/index.d.ts
+++ b/src/components/CheckboxGroup/index.d.ts
@@ -16,6 +16,7 @@ export interface CheckboxGroupProps extends BaseProps {
     error?: ReactNode;
     onChange?: (values: string[]) => void;
     id?: string;
+    orientation?: string;
 }
 
 declare const CheckboxGroup: ComponentType<CheckboxGroupProps>;

--- a/src/components/CheckboxGroup/index.d.ts
+++ b/src/components/CheckboxGroup/index.d.ts
@@ -16,7 +16,7 @@ export interface CheckboxGroupProps extends BaseProps {
     error?: ReactNode;
     onChange?: (values: string[]) => void;
     id?: string;
-    orientation?: string;
+    orientation?: 'vertical' | 'horizontal';
 }
 
 declare const CheckboxGroup: ComponentType<CheckboxGroupProps>;

--- a/src/components/CheckboxGroup/index.js
+++ b/src/components/CheckboxGroup/index.js
@@ -7,7 +7,7 @@ import RequiredAsterisk from '../RequiredAsterisk';
 import CheckboxList from './checkboxList';
 import StyledFieldset from './styled/fieldset';
 import StyledLegend from './styled/legend';
-import StyledContantContainer from './styled/contentContainer';
+import StyledContentContainer from './styled/contentContainer';
 import StyledTextError from '../Input/styled/errorText';
 
 /**
@@ -51,7 +51,7 @@ class CheckboxGroup extends Component {
     }
 
     render() {
-        const { id, options, required, label, error, style, className } = this.props;
+        const { id, options, required, label, error, style, className, orientation } = this.props;
         return (
             <StyledFieldset id={id} className={className} style={style}>
                 <RenderIf isTrue={!!label}>
@@ -60,7 +60,7 @@ class CheckboxGroup extends Component {
                         {label}
                     </StyledLegend>
                 </RenderIf>
-                <StyledContantContainer>
+                <StyledContentContainer orientation={orientation}>
                     <CheckboxList
                         values={this.getValue()}
                         options={options}
@@ -69,7 +69,7 @@ class CheckboxGroup extends Component {
                         describedBy={this.getErrorMessageId()}
                         error={error}
                     />
-                </StyledContantContainer>
+                </StyledContentContainer>
                 <RenderIf isTrue={!!error}>
                     <StyledTextError id={this.getErrorMessageId()}>{error}</StyledTextError>
                 </RenderIf>
@@ -106,6 +106,8 @@ CheckboxGroup.propTypes = {
     style: PropTypes.object,
     /** The id of the outer element. */
     id: PropTypes.string,
+    /** The orientation of the element. */
+    orientation: PropTypes.oneOf(['vertical', 'horizontal']),
 };
 
 CheckboxGroup.defaultProps = {
@@ -119,6 +121,7 @@ CheckboxGroup.defaultProps = {
     className: undefined,
     style: undefined,
     id: undefined,
+    orientation: 'vertical',
 };
 
 export default withReduxForm(CheckboxGroup);

--- a/src/components/CheckboxGroup/readme.md
+++ b/src/components/CheckboxGroup/readme.md
@@ -272,3 +272,46 @@ const CheckBoxGroupProfile = () => {
 
 <CheckBoxGroupProfile />
 ```
+
+##### Checkbox Group horizontal
+
+```js
+import React from 'react';
+import { CheckboxGroup } from 'react-rainbow-components';
+
+const options = [
+    { value: 'checkboxOne', label: 'Checkbox One', disabled: false },
+    { value: 'checkboxTwo', label: 'Checkbox Two', disabled: false },
+    { value: 'checkboxThree', label: 'Checkbox Three', disabled: false },
+];
+
+class CheckboxGroupTry extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { values: [] };
+        this.handleOnChange = this.handleOnChange.bind(this);
+    }
+
+    handleOnChange(values) {
+        this.setState({ values });
+    }
+
+    render() {
+        const { values } = this.state;
+        return (
+            <div className="rainbow-p-vertical_large rainbow-p-left_xx-large">
+                <CheckboxGroup
+                    id="checkbox-group-1"
+                    label="Checkbox Group Label"
+                    options={options}
+                    value={values}
+                    onChange={this.handleOnChange}
+                    orientation="horizontal"
+                />
+            </div>
+        );
+    }
+}
+
+<CheckboxGroupTry />;
+```

--- a/src/components/CheckboxGroup/readme.md
+++ b/src/components/CheckboxGroup/readme.md
@@ -276,7 +276,7 @@ const CheckBoxGroupProfile = () => {
 ##### Checkbox Group horizontal
 
 ```js
-import React from 'react';
+import React, { useState } from 'react';
 import { CheckboxGroup } from 'react-rainbow-components';
 
 const options = [
@@ -285,33 +285,25 @@ const options = [
     { value: 'checkboxThree', label: 'Checkbox Three', disabled: false },
 ];
 
-class CheckboxGroupTry extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = { values: [] };
-        this.handleOnChange = this.handleOnChange.bind(this);
+const CheckboxGroupTry = () => {
+    const [values, setValues] = useState([]);
+    
+    const handleOnChange = values => {
+        setValues(values);
     }
 
-    handleOnChange(values) {
-        this.setState({ values });
-    }
-
-    render() {
-        const { values } = this.state;
-        return (
-            <div className="rainbow-p-vertical_large rainbow-p-left_xx-large">
-                <CheckboxGroup
-                    id="checkbox-group-1"
-                    label="Checkbox Group Label"
-                    options={options}
-                    value={values}
-                    onChange={this.handleOnChange}
-                    orientation="horizontal"
-                />
-            </div>
-        );
-    }
+    return (
+        <CheckboxGroup
+            id="checkbox-group-1"
+            options={options}
+            value={values}
+            onChange={handleOnChange}
+            label="Checkbox Group Label"
+            orientation="horizontal"
+        />
+    );
 }
-
-<CheckboxGroupTry />;
+<div className="rainbow-p-vertical_large rainbow-p-left_xx-large">
+    <CheckboxGroupTry />
+</div>;
 ```

--- a/src/components/CheckboxGroup/styled/contentContainer.js
+++ b/src/components/CheckboxGroup/styled/contentContainer.js
@@ -1,10 +1,21 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { PADDING_MEDIUM } from '../../../styles/paddings';
 
-const StyledContantContainer = styled.div`
+const StyledContentContainer = styled.div`
     display: flex;
-    flex-direction: column;
+    flex-direction: ${({ orientation }) => (orientation === 'vertical' ? 'column' : 'row')};
     align-items: flex-start;
     justify-content: flex-start;
+
+    ${({ orientation }) =>
+        orientation === 'horizontal' &&
+        css`
+            & > div {
+                padding-right: ${PADDING_MEDIUM};
+            }
+        `}
 `;
 
-export default StyledContantContainer;
+StyledContentContainer.displayName = 'CheckboxGroupStyledContentContainer';
+
+export default StyledContentContainer;

--- a/src/components/CheckboxGroup/styled/contentContainer.js
+++ b/src/components/CheckboxGroup/styled/contentContainer.js
@@ -6,7 +6,6 @@ const StyledContentContainer = styled.div`
     flex-direction: ${({ orientation }) => (orientation === 'vertical' ? 'column' : 'row')};
     align-items: flex-start;
     justify-content: flex-start;
-
     ${({ orientation }) =>
         orientation === 'horizontal' &&
         css`

--- a/src/components/RadioGroup/__test__/radioGroup.spec.js
+++ b/src/components/RadioGroup/__test__/radioGroup.spec.js
@@ -14,7 +14,7 @@ describe('<RadioGroup />', () => {
         );
     });
 
-    it('renders correctly in vertical orientation (implicit)', () => {
+    it('renders correctly in vertical orientation (explicit)', () => {
         const options = [{ value: 'admin', label: 'Admin' }, { value: 'user', label: 'User' }];
 
         const component = mount(<RadioGroup options={options} orientation="vertical" />);
@@ -25,7 +25,7 @@ describe('<RadioGroup />', () => {
         );
     });
 
-    it('renders correctly in horizontal orientation (implicit)', () => {
+    it('renders correctly in horizontal orientation (explicit)', () => {
         const options = [{ value: 'admin', label: 'Admin' }, { value: 'user', label: 'User' }];
 
         const component = mount(<RadioGroup options={options} orientation="horizontal" />);

--- a/src/components/RadioGroup/__test__/radioGroup.spec.js
+++ b/src/components/RadioGroup/__test__/radioGroup.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import RadioGroup from '../../RadioGroup';
+import RadioGroup from '../index';
 
 describe('<RadioGroup />', () => {
     it('renders correctly in vertical orientation (default)', () => {

--- a/src/components/RadioGroup/__test__/radioGroup.spec.js
+++ b/src/components/RadioGroup/__test__/radioGroup.spec.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import RadioGroup from '../../RadioGroup';
+
+describe('<RadioGroup />', () => {
+    it('renders correctly in vertical orientation (default)', () => {
+        const options = [{ value: 'admin', label: 'Admin' }, { value: 'user', label: 'User' }];
+
+        const component = mount(<RadioGroup options={options} />);
+        const elem = component.find('RadioGroupStyledContentContainer');
+
+        expect(getComputedStyle(elem.getDOMNode()).getPropertyValue('flex-direction')).toBe(
+            'column',
+        );
+    });
+
+    it('renders correctly in vertical orientation (implicit)', () => {
+        const options = [{ value: 'admin', label: 'Admin' }, { value: 'user', label: 'User' }];
+
+        const component = mount(<RadioGroup options={options} orientation="vertical" />);
+        const elem = component.find('RadioGroupStyledContentContainer');
+
+        expect(getComputedStyle(elem.getDOMNode()).getPropertyValue('flex-direction')).toBe(
+            'column',
+        );
+    });
+
+    it('renders correctly in horizontal orientation (implicit)', () => {
+        const options = [{ value: 'admin', label: 'Admin' }, { value: 'user', label: 'User' }];
+
+        const component = mount(<RadioGroup options={options} orientation="horizontal" />);
+        const elem = component.find('RadioGroupStyledContentContainer');
+
+        expect(getComputedStyle(elem.getDOMNode()).getPropertyValue('flex-direction')).toBe('row');
+    });
+});

--- a/src/components/RadioGroup/index.d.ts
+++ b/src/components/RadioGroup/index.d.ts
@@ -10,6 +10,7 @@ export interface RadioGroupProps extends BaseProps {
     options?: RadioOption[];
     error?: ReactNode;
     id?: string;
+    orientation?: string;
 }
 
 declare const RadioGroup: ComponentType<RadioGroupProps>;

--- a/src/components/RadioGroup/index.d.ts
+++ b/src/components/RadioGroup/index.d.ts
@@ -10,7 +10,7 @@ export interface RadioGroupProps extends BaseProps {
     options?: RadioOption[];
     error?: ReactNode;
     id?: string;
-    orientation?: string;
+    orientation?: 'vertical' | 'horizontal';
 }
 
 declare const RadioGroup: ComponentType<RadioGroupProps>;

--- a/src/components/RadioGroup/index.js
+++ b/src/components/RadioGroup/index.js
@@ -40,6 +40,7 @@ class RadioGroup extends Component {
             options,
             value,
             id,
+            orientation,
         } = this.props;
 
         return (
@@ -50,7 +51,7 @@ class RadioGroup extends Component {
                         {label}
                     </StyledLegend>
                 </RenderIf>
-                <StyledContentContainer>
+                <StyledContentContainer orientation={orientation}>
                     <RadioItmes
                         value={value}
                         onChange={onChange}
@@ -95,6 +96,8 @@ RadioGroup.propTypes = {
     style: PropTypes.object,
     /** The id of the outer element. */
     id: PropTypes.string,
+    /** The orientation of the element. */
+    orientation: PropTypes.oneOf(['vertical', 'horizontal']),
 };
 
 RadioGroup.defaultProps = {
@@ -108,6 +111,7 @@ RadioGroup.defaultProps = {
     options: [],
     error: null,
     id: undefined,
+    orientation: 'vertical',
 };
 
 export default withReduxForm(RadioGroup);

--- a/src/components/RadioGroup/readme.md
+++ b/src/components/RadioGroup/readme.md
@@ -172,7 +172,7 @@ class ErrorRadioGroup extends React.Component {
 ##### radio group horizontal
 
 ```js
-import React from 'react';
+import React, { useState } from 'react';
 import { RadioGroup } from 'react-rainbow-components';
 
 const options = [
@@ -181,31 +181,23 @@ const options = [
     { value: 'radioThree', label: 'Radio Three' },
 ];
 
-class SimpleRadioGroup extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            value: undefined,
-        };
-        this.handleOnChange = this.handleOnChange.bind(this);
+const SimpleRadioGroup = () => {
+    const [value, setValue] = useState('anonymous');
+    
+    const handleOnChange = event => {
+        setValue(event.target.value);
     }
 
-    handleOnChange(event) {
-        return this.setState({ value: event.target.value });
-    }
-
-    render() {
-        return (
-            <RadioGroup
-                id="radio-group-component-1"
-                options={options}
-                value={this.state.value}
-                onChange={this.handleOnChange}
-                label="Radio Group Label"
-                orientation="horizontal"
-            />
-        );
-    }
+    return (
+        <RadioGroup
+            id="radio-group-component-1"
+            options={options}
+            value={value}
+            onChange={handleOnChange}
+            label="Radio Group Label"
+            orientation="horizontal"
+        />
+    );
 }
 
 <div className="rainbow-p-vertical_large rainbow-p-left_xx-large">

--- a/src/components/RadioGroup/readme.md
+++ b/src/components/RadioGroup/readme.md
@@ -168,3 +168,47 @@ class ErrorRadioGroup extends React.Component {
     <ErrorRadioGroup />
 </div>
 ```
+
+##### radio group horizontal
+
+```js
+import React from 'react';
+import { RadioGroup } from 'react-rainbow-components';
+
+const options = [
+    { value: 'radioOne', label: 'Radio One' },
+    { value: 'radioTwo', label: 'Radio Two' },
+    { value: 'radioThree', label: 'Radio Three' },
+];
+
+class SimpleRadioGroup extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: undefined,
+        };
+        this.handleOnChange = this.handleOnChange.bind(this);
+    }
+
+    handleOnChange(event) {
+        return this.setState({ value: event.target.value });
+    }
+
+    render() {
+        return (
+            <RadioGroup
+                id="radio-group-component-1"
+                options={options}
+                value={this.state.value}
+                onChange={this.handleOnChange}
+                label="Radio Group Label"
+                orientation="horizontal"
+            />
+        );
+    }
+}
+
+<div className="rainbow-p-vertical_large rainbow-p-left_xx-large">
+    <SimpleRadioGroup />
+</div>
+```

--- a/src/components/RadioGroup/styled/contentContainer.js
+++ b/src/components/RadioGroup/styled/contentContainer.js
@@ -1,10 +1,21 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { PADDING_MEDIUM } from '../../../styles/paddings';
 
 const StyledContentContainer = styled.div`
     display: flex;
-    flex-direction: column;
+    flex-direction: ${({ orientation }) => (orientation === 'vertical' ? 'column' : 'row')};
     align-items: flex-start;
     justify-content: flex-start;
+
+    ${({ orientation }) =>
+        orientation === 'horizontal' &&
+        css`
+            & > div {
+                padding-right: ${PADDING_MEDIUM};
+            }
+        `}
 `;
+
+StyledContentContainer.displayName = 'RadioGroupStyledContentContainer';
 
 export default StyledContentContainer;

--- a/src/components/RadioGroup/styled/contentContainer.js
+++ b/src/components/RadioGroup/styled/contentContainer.js
@@ -6,7 +6,6 @@ const StyledContentContainer = styled.div`
     flex-direction: ${({ orientation }) => (orientation === 'vertical' ? 'column' : 'row')};
     align-items: flex-start;
     justify-content: flex-start;
-
     ${({ orientation }) =>
         orientation === 'horizontal' &&
         css`


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1824 

## Screenshots

![image](https://user-images.githubusercontent.com/9373787/93657622-081f5e80-fa2c-11ea-93aa-090a6f9eab88.png)

![image](https://user-images.githubusercontent.com/9373787/93657653-3d2bb100-fa2c-11ea-95d5-e39b749961fd.png)

![image](https://user-images.githubusercontent.com/9373787/93657659-4f0d5400-fa2c-11ea-8fc7-1b273c7e4084.png)

![image](https://user-images.githubusercontent.com/9373787/93657667-5fbdca00-fa2c-11ea-8efc-055a2e400f17.png)

## Changes proposed in this PR:
- Add optional orientation prop to radio group and checkbox group (default vertical)
- Possible values ['horizontal', 'vertical]

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
