### PR TITLE
fix: add ref type to BaseProps in the typescript interface

### DIFF
--- a/src/components/types.d.ts
+++ b/src/components/types.d.ts
@@ -1,8 +1,9 @@
-import { ReactNode, CSSProperties } from 'react';
+import { ReactNode, CSSProperties, Ref } from 'react';
 
 export interface BaseProps {
     className?: string;
     style?: CSSProperties;
+    ref?: Ref<any>;
 }
 
 export type AvatarSize = 'x-small' | 'small' | 'medium' | 'large';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1839 

## Changes proposed in this PR:
- add ref type to BaseProps in the typescript interface

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
