### PR TITLE
test: add test to check PhoneInput if only one country or an empty ar…

### DIFF
--- a/src/components/PhoneInput/__tests__/phoneinput.spec.js
+++ b/src/components/PhoneInput/__tests__/phoneinput.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import PhoneInput from '../';
+import { StyledTrigger } from '../styled';
 
 describe('<PhoneInput />', () => {
     it('should accept only numbers.', () => {
@@ -18,5 +19,17 @@ describe('<PhoneInput />', () => {
                 phone: '0987256983',
             }),
         );
+    });
+
+    it('should render the dropdown option when an empty array is passed in countries prop', () => {
+        const countries = [];
+        const wrapper = mount(<PhoneInput countries={countries} />);
+        expect(wrapper.find(StyledTrigger).prop('onClick')).toBeDefined();
+    });
+
+    it('should not render the dropdown option when only one country is passed', () => {
+        const countries = ['mx'];
+        const wrapper = mount(<PhoneInput countries={countries} />);
+        expect(wrapper.find(StyledTrigger).prop('onClick')).toBe(undefined);
     });
 });


### PR DESCRIPTION
…ray  is passed

<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1701 

## Changes proposed in this PR:
-add test to check the dropdown shows when an empty array is passed in countries prop
-add test to check the dropdown does not show when only one country is passed

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
