### PR TITLE
fix: send value in focus and blur events in PhoneInput

### DIFF
--- a/src/components/PhoneInput/__tests__/phoneInput.a11y.spec.js
+++ b/src/components/PhoneInput/__tests__/phoneInput.a11y.spec.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import axe from '../../../../axe';
+import PhoneInput from '..';
+
+describe('<PhoneInput/>', () => {
+    // TODO: fix united states icon flag has duplicate id usage
+    it.skip('should be accessible when label is passed', async () => {
+        expect.assertions(1);
+        const html = ReactDOMServer.renderToString(<PhoneInput label="Phone Input Label" />);
+        const results = await axe(html);
+        expect(results).toHaveNoViolations();
+    });
+});

--- a/src/components/PhoneInput/__tests__/phoneinput.spec.js
+++ b/src/components/PhoneInput/__tests__/phoneinput.spec.js
@@ -4,15 +4,79 @@ import PhoneInput from '..';
 import { StyledTrigger } from '../styled';
 
 describe('<PhoneInput />', () => {
+    it('should fire onChange with the right value', () => {
+        const onChangeMockFn = jest.fn();
+        const component = mount(<PhoneInput label="Phone Number" onChange={onChangeMockFn} />);
+        component.find('input[type="tel"]').simulate('change', { target: { value: '12345678' } });
+        expect(onChangeMockFn).toHaveBeenCalledWith({
+            countryCode: '+1',
+            isoCode: 'us',
+            phone: '12345678',
+        });
+    });
+    it('should fire onFocus with the right value', () => {
+        const onFocusMockFn = jest.fn();
+        const component = mount(<PhoneInput label="Phone Number" onFocus={onFocusMockFn} />);
+        component.find('input[type="tel"]').simulate('focus');
+        expect(true).toBe(true);
+        expect(onFocusMockFn).toHaveBeenCalledWith({
+            countryCode: '+1',
+            isoCode: 'us',
+            phone: '',
+        });
+    });
+    it('should fire onBlur with the right value', () => {
+        const onBlurMockFn = jest.fn();
+        const component = mount(<PhoneInput label="Phone Number" onBlur={onBlurMockFn} />);
+        component.find('input[type="tel"]').simulate('blur');
+        expect(onBlurMockFn).toHaveBeenCalledWith({
+            countryCode: '+1',
+            isoCode: 'us',
+            phone: '',
+        });
+    });
+    it('should fire onFocus with the right value when has an initial value', () => {
+        const onFocusMockFn = jest.fn();
+        const value = {
+            countryCode: '+52',
+            isoCode: 'mx',
+            phone: '1234',
+        };
+        const component = mount(
+            <PhoneInput label="Phone Number" value={value} onFocus={onFocusMockFn} />,
+        );
+        component.find('input[type="tel"]').simulate('focus');
+        expect(true).toBe(true);
+        expect(onFocusMockFn).toHaveBeenCalledWith({
+            countryCode: '+52',
+            isoCode: 'mx',
+            phone: '1234',
+        });
+    });
+    it('should fire onBlur with the right value when has an initial value', () => {
+        const onBlurMockFn = jest.fn();
+        const value = {
+            countryCode: '+53',
+            isoCode: 'cu',
+            phone: '12345',
+        };
+        const component = mount(
+            <PhoneInput label="Phone Number" value={value} onBlur={onBlurMockFn} />,
+        );
+        component.find('input[type="tel"]').simulate('blur');
+        expect(onBlurMockFn).toHaveBeenCalledWith({
+            countryCode: '+53',
+            isoCode: 'cu',
+            phone: '12345',
+        });
+    });
     it('should accept only numbers.', () => {
         const onChangeMockFn = jest.fn();
-        const wrapper = mount(<PhoneInput label="Phone Number" onChange={onChangeMockFn} />);
+        const component = mount(<PhoneInput label="Phone Number" onChange={onChangeMockFn} />);
 
-        wrapper
+        component
             .find('input[type="tel"]')
-            .first()
             .simulate('change', { target: { value: 'Your phone number is 0987256983' } });
-        wrapper.update();
 
         expect(onChangeMockFn).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -20,13 +84,11 @@ describe('<PhoneInput />', () => {
             }),
         );
     });
-
     it('should render the dropdown option when an empty array is passed in countries prop', () => {
         const countries = [];
         const wrapper = mount(<PhoneInput countries={countries} />);
         expect(wrapper.find(StyledTrigger).prop('onClick')).toBeDefined();
     });
-
     it('should not render the dropdown option when only one country is passed', () => {
         const countries = ['mx'];
         const wrapper = mount(<PhoneInput countries={countries} />);

--- a/src/components/PhoneInput/hooks/useHandleBlur.js
+++ b/src/components/PhoneInput/hooks/useHandleBlur.js
@@ -1,12 +1,9 @@
 import { useCallback } from 'react';
 
-export default function useHandleBlur(focusIndex, onBlur) {
-    return useCallback(
-        event => {
-            if (focusIndex === -1) {
-                onBlur(event);
-            }
-        },
-        [focusIndex, onBlur],
-    );
+export default function useHandleBlur(focusIndex, onBlur, value) {
+    return useCallback(() => {
+        if (focusIndex === -1) {
+            onBlur(value);
+        }
+    }, [focusIndex, onBlur, value]);
 }

--- a/src/components/PhoneInput/hooks/useHandleFocus.js
+++ b/src/components/PhoneInput/hooks/useHandleFocus.js
@@ -1,16 +1,16 @@
 import { useCallback } from 'react';
 
-export default function useHandleFocus(focusIndex, onFocus, setFocusIndex) {
+export default function useHandleFocus(focusIndex, onFocus, setFocusIndex, value) {
     return useCallback(
         (event, index) => {
             if ((index === 0 && focusIndex === 1) || index === focusIndex) {
                 return;
             }
             if (focusIndex === -1) {
-                onFocus(event);
+                onFocus(value);
             }
             setFocusIndex(index);
         },
-        [focusIndex, onFocus, setFocusIndex],
+        [focusIndex, onFocus, setFocusIndex, value],
     );
 }

--- a/src/components/PhoneInput/index.js
+++ b/src/components/PhoneInput/index.js
@@ -7,6 +7,7 @@ import RenderIf from '../RenderIf';
 import StyledContainer from '../Input/styled/container';
 import HelpText from '../Input/styled/helpText';
 import ErrorText from '../Input/styled/errorText';
+import AssistiveText from '../AssistiveText';
 import {
     StyledInputContainer,
     StyledInput,
@@ -94,8 +95,8 @@ const PhoneInput = React.forwardRef((props, ref) => {
         focusIndex > -1,
     );
 
-    const handleFocus = useHandleFocus(focusIndex, onFocus, setFocusIndex);
-    const handleBlur = useHandleBlur(focusIndex, onBlur);
+    const handleFocus = useHandleFocus(focusIndex, onFocus, setFocusIndex, value);
+    const handleBlur = useHandleBlur(focusIndex, onBlur, value);
 
     const isOpen = focusIndex === 1;
     const handleCountryChange = useHandleCountryChange(phone, onChange, setFocusIndex, isOpen);
@@ -155,11 +156,13 @@ const PhoneInput = React.forwardRef((props, ref) => {
                         onBlur={handleBlur}
                         tabIndex={tabIndex}
                         disabled={disabled}
+                        type="button"
                     >
                         <StyledFlagContainer disabled={disabled}>
                             {flagIcon}
                             <StyledIndicator error={error} disabled={disabled} />
                         </StyledFlagContainer>
+                        <AssistiveText text="select country" />
                     </StyledTrigger>
                 </RenderIf>
                 <RenderIf isTrue={isOnlyCountry}>
@@ -224,7 +227,14 @@ const PhoneInput = React.forwardRef((props, ref) => {
 
 PhoneInput.propTypes = {
     /** Specifies the value of an input element. */
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.shape({
+            countryCode: PropTypes.string,
+            isoCode: PropTypes.string,
+            phone: PropTypes.string,
+        }),
+    ]),
     /** The name of the input. */
     name: PropTypes.string,
     /** Text label for the input. */
@@ -289,7 +299,11 @@ PhoneInput.defaultProps = {
     onFocus: () => {},
     onBlur: () => {},
     onChange: () => {},
-    value: undefined,
+    value: {
+        countryCode: '+1',
+        isoCode: 'us',
+        phone: '',
+    },
     countries: [
         'af',
         'ax',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1911 

## Changes proposed in this PR:
- send value in focus and blur events in PhoneInput

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
