### PR TITLE
Fix: Update ButtonMenu types

### DIFF
--- a/src/components/ButtonMenu/index.d.ts
+++ b/src/components/ButtonMenu/index.d.ts
@@ -18,6 +18,7 @@ export interface ButtonMenuProps extends BaseProps {
     onFocus?: (event: FocusEvent<HTMLElement>) => void;
     onBlur?: (event: FocusEvent<HTMLElement>) => void;
     id?: string;
+    label?: ReactNode;
 }
 
 export default function(props: ButtonMenuProps): JSX.Element | null;


### PR DESCRIPTION
Missing label type.

<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: update ButtonMenu types

## Changes proposed in this PR:
-

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
