### PR TITLE
refactor: add new variant 'bare on components using isBare

### DIFF
--- a/src/components/CounterInput/index.d.ts
+++ b/src/components/CounterInput/index.d.ts
@@ -22,7 +22,7 @@ export interface CounterInputProps extends BaseProps {
     isBare?: boolean;
     error?: ReactNode;
     step?: number;
-    variant?: 'default' | 'shaded';
+    variant?: 'default' | 'shaded' | 'bare';
     onChange?: (value: number) => void;
     onFocus?: (value: number) => void;
     onBlur?: (value: number) => void;

--- a/src/components/CounterInput/index.js
+++ b/src/components/CounterInput/index.js
@@ -194,13 +194,11 @@ CounterInput.propTypes = {
     min: PropTypes.number,
     /** Specifies the maximum value allowed in the field. */
     max: PropTypes.number,
-    /** Specifies that an input will not have border. This value defaults to false. */
-    isBare: PropTypes.bool,
     /** Specifies the error that the input contains. */
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     /** The variant changes the appearance of the Input. Accepted variants include default
      * and shaded. This value defaults to default. */
-    variant: PropTypes.oneOf(['default', 'shaded']),
+    variant: PropTypes.oneOf(['default', 'shaded', 'bare']),
     /** A number that specifies the granularity that the value must adhere to. */
     step: PropTypes.number,
     /** Text label for the Input. */
@@ -228,7 +226,6 @@ CounterInput.defaultProps = {
     required: false,
     min: undefined,
     max: undefined,
-    isBare: false,
     error: null,
     step: 1,
     variant: 'default',

--- a/src/components/CounterInput/styled/index.js
+++ b/src/components/CounterInput/styled/index.js
@@ -80,6 +80,13 @@ export const StyledInput = attachThemeAttrs(styled.input)`
     `}
 
     ${props =>
+        props.variant === 'bare' &&
+        `
+        background: transparent;
+        border-color: transparent;
+        `}
+
+    ${props =>
         props.error &&
         `
         background-color: ${props.palette.background.main};

--- a/src/components/Input/index.d.ts
+++ b/src/components/Input/index.d.ts
@@ -56,7 +56,7 @@ export interface InputProps extends BaseProps {
     onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void;
     checked?: boolean;
     id?: string;
-    variant?: 'default' | 'shaded';
+    variant?: 'default' | 'shaded' | 'bare';
     autoComplete?: string;
 }
 

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -135,7 +135,7 @@ Input.propTypes = {
     style: PropTypes.object,
     /** The variant changes the appearance of the Input. Accepted variants include default,
      * and shaded. This value defaults to default. */
-    variant: PropTypes.oneOf(['default', 'shaded']),
+    variant: PropTypes.oneOf(['default', 'shaded', 'bare']),
     /** The id of the outer element. */
     id: PropTypes.string,
     /** A string indicating the type of autocomplete functionality.

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -109,8 +109,6 @@ Input.propTypes = {
     pattern: PropTypes.string,
     /** Specifies that an input text will be centered. This value defaults to false. */
     isCentered: PropTypes.bool,
-    /** Specifies that an input will not have border. This value defaults to false. */
-    isBare: PropTypes.bool,
     /** Specifies that an input field must be filled out before submitting the form. */
     error: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     /** Specifies that an input element should be disabled. This value defaults to false. */
@@ -166,7 +164,6 @@ Input.defaultProps = {
     required: false,
     pattern: undefined,
     isCentered: false,
-    isBare: false,
     error: null,
     disabled: false,
     readOnly: false,

--- a/src/components/Input/styled/input.js
+++ b/src/components/Input/styled/input.js
@@ -68,6 +68,14 @@ const Input = attachThemeAttrs(styled.input)`
         box-shadow:${props.disabled || props.readOnly ? '' : props.shadows.shadow_10};
         border: 1px solid transparent;
         `}
+
+        ${props =>
+            props.variant === 'bare' &&
+            `
+            background: transparent;
+            border-color: transparent;
+            `}
+    
     ${props =>
         props.error &&
         `

--- a/src/components/MultiSelect/index.d.ts
+++ b/src/components/MultiSelect/index.d.ts
@@ -16,7 +16,7 @@ export interface MultiSelectProps extends BaseProps {
     required?: boolean;
     disabled?: boolean;
     readOnly?: boolean;
-    variant?: 'default' | 'chip';
+    variant?: 'default' | 'chip' | 'bare';
     chipVariant?: 'base' | 'neutral' | 'outline-brand' | 'brand';
     isBare?: boolean;
     labelAlignment?: LabelAlignment;

--- a/src/components/MultiSelect/index.js
+++ b/src/components/MultiSelect/index.js
@@ -211,6 +211,7 @@ const MultiSelect = React.forwardRef((props, ref) => {
                 onKeyDown={handleKeyDown}
                 ref={comboboxRef}
                 aria-labelledby={labelId}
+                variant={variant}
             >
                 <StyledInput
                     id={inputId}
@@ -317,11 +318,9 @@ MultiSelect.propTypes = {
     /** Specifies the tab order of an element (when the tab button is used for navigating). */
     tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     /** Specifies the variant for the input. */
-    variant: PropTypes.oneOf(['default', 'chip']),
+    variant: PropTypes.oneOf(['default', 'chip', 'bare']),
     /** Specifies the variant for the chips. */
     chipVariant: PropTypes.oneOf(['base', 'neutral', 'outline-brand', 'brand']),
-    /** Specifies that an input will not have border. This value defaults to false. */
-    isBare: PropTypes.bool,
     /** Specifies the value of an input element. */
     value: PropTypes.arrayOf(
         PropTypes.shape({
@@ -358,7 +357,6 @@ MultiSelect.defaultProps = {
     tabIndex: 0,
     variant: 'default',
     chipVariant: 'base',
-    isBare: false,
     value: undefined,
     onChange: () => {},
     onFocus: () => {},

--- a/src/components/MultiSelect/readme.md
+++ b/src/components/MultiSelect/readme.md
@@ -103,7 +103,7 @@ const MultiSelectExample = () => {
             value={value}
             onChange={setValue}
             bottomHelpText="You can select several options"
-            isBare
+            variant='bare'
         >
             <Option name="option-1" label="All Buildings" icon={<DashboardIcon />} />
             <Option name="option-2" label="New Building" icon={<AddFilledIcon />} />

--- a/src/components/MultiSelect/styled/index.js
+++ b/src/components/MultiSelect/styled/index.js
@@ -46,6 +46,13 @@ export const StyledCombobox = attachThemeAttrs(styled.div)`
         border-color: transparent;
         `}
 
+    ${props =>
+        props.variant === 'bare' &&
+        `
+        background: transparent;
+        border-color: transparent;
+        `}
+
     :focus,
     :active,
     :focus-within {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #1934 

## Changes proposed in this PR:
-remove isBare from propTypes and defaultProps on CounterInput.js, Input.js and MultiSelect.js components
-add new variant 'bare on CounterInput.js, Input.js and MultiSelect.js components
-add new variant 'bare on .ts files
-use prop variant
-add new style rule considering variant==='bare' on the styled files for CounterInput.js, Input.js and MultiSelect.js

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
