### PR TITLE
Fixed 🛠 Pagination Buttons 🔼🔽.

### DIFF
--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -21,28 +21,43 @@ export default function Pagination(props) {
     return (
         <StyledNav className={className} aria-label="pagination" style={style}>
             <StyledPaginationContainer>
-                <NavigationButton
-                    dataId="previous-page-button"
-                    icon={<LeftArrow />}
-                    onClick={event => onChange(event, activePage - 1)}
-                    disabled={isFirstItemSelected}
-                    ariaLabel="Goto Previous Page"
-                    variant={variant}
-                />
-                <PageButtonsContainer
-                    onChange={onChange}
-                    pages={pages}
-                    activePage={activePage}
-                    variant={variant}
-                />
-                <NavigationButton
-                    dataId="next-page-button"
-                    icon={<RightArrow />}
-                    onClick={event => onChange(event, activePage + 1)}
-                    disabled={isLastItemSelected}
-                    ariaLabel="Goto Next Page"
-                    variant={variant}
-                />
+                {
+                    pages === 1 ? (
+                        <>
+                            <NavigationButton
+                                dataId="previous-page-button"
+                                icon={<LeftArrow />}
+                                onClick={event => onChange(event, activePage - 1)}
+                                disabled={isFirstItemSelected}
+                                ariaLabel="Goto Previous Page"
+                                variant={variant}
+                            />
+                            <PageButtonsContainer
+                                onChange={onChange}
+                                pages={pages}
+                                activePage={activePage}
+                                variant={variant}
+                            />
+                            <NavigationButton
+                                dataId="next-page-button"
+                                icon={<RightArrow />}
+                                onClick={event => onChange(event, activePage + 1)}
+                                disabled={isLastItemSelected}
+                                ariaLabel="Goto Next Page"
+                                variant={variant}
+                            />
+                        </>
+                    ) : (
+                        <>
+                            <PageButtonsContainer
+                                onChange={onChange}
+                                pages={pages}
+                                activePage={activePage}
+                                variant={variant}
+                            />
+                        </>
+                    )
+                }
             </StyledPaginationContainer>
         </StyledNav>
     );

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -6,6 +6,7 @@ import NavigationButton from './navigationButton';
 import PageButtonsContainer from './pageButtonsContainer';
 import StyledNav from './styled/nav';
 import StyledPaginationContainer from './styled/paginationContainer';
+import RenderIf from '../RenderIf';
 
 /**
  * The Pagination component shows you the pagination options for dividing content into pages.
@@ -21,43 +22,28 @@ export default function Pagination(props) {
     return (
         <StyledNav className={className} aria-label="pagination" style={style}>
             <StyledPaginationContainer>
-                {
-                    pages === 1 ? (
-                        <>
-                            <NavigationButton
-                                dataId="previous-page-button"
-                                icon={<LeftArrow />}
-                                onClick={event => onChange(event, activePage - 1)}
-                                disabled={isFirstItemSelected}
-                                ariaLabel="Goto Previous Page"
-                                variant={variant}
-                            />
-                            <PageButtonsContainer
-                                onChange={onChange}
-                                pages={pages}
-                                activePage={activePage}
-                                variant={variant}
-                            />
-                            <NavigationButton
-                                dataId="next-page-button"
-                                icon={<RightArrow />}
-                                onClick={event => onChange(event, activePage + 1)}
-                                disabled={isLastItemSelected}
-                                ariaLabel="Goto Next Page"
-                                variant={variant}
-                            />
-                        </>
-                    ) : (
-                        <>
-                            <PageButtonsContainer
-                                onChange={onChange}
-                                pages={pages}
-                                activePage={activePage}
-                                variant={variant}
-                            />
-                        </>
-                    )
-                }
+                <NavigationButton
+                    dataId="previous-page-button"
+                    icon={<LeftArrow />}
+                    onClick={event => onChange(event, activePage - 1)}
+                    disabled={isFirstItemSelected}
+                    ariaLabel="Goto Previous Page"
+                    variant={variant}
+                />
+                <PageButtonsContainer
+                    onChange={onChange}
+                    pages={pages}
+                    activePage={activePage}
+                    variant={variant}
+                />
+                <NavigationButton
+                    dataId="next-page-button"
+                    icon={<RightArrow />}
+                    onClick={event => onChange(event, activePage + 1)}
+                    disabled={isLastItemSelected}
+                    ariaLabel="Goto Next Page"
+                    variant={variant}
+                />
             </StyledPaginationContainer>
         </StyledNav>
     );

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -6,7 +6,6 @@ import NavigationButton from './navigationButton';
 import PageButtonsContainer from './pageButtonsContainer';
 import StyledNav from './styled/nav';
 import StyledPaginationContainer from './styled/paginationContainer';
-import RenderIf from '../RenderIf';
 
 /**
  * The Pagination component shows you the pagination options for dividing content into pages.

--- a/src/components/Pagination/styled/pageButton.js
+++ b/src/components/Pagination/styled/pageButton.js
@@ -21,6 +21,14 @@ const StyledPageButton = styled.li`
     }
 
     ${props =>
+        props.pages === 1 &&
+        `
+            :nth-child(1) > button {
+                border-radius: 100px;
+            } 
+        `}
+
+    ${props =>
         props.variant === 'shaded' &&
         `
         > button {
@@ -37,7 +45,7 @@ const StyledPageButton = styled.li`
             border-radius: 0;
         }
         :nth-child(1) > button {
-            border-radius: 100px;
+            border-radius: 100px 0 0 100px;
         }
 
         :nth-last-child(1) > button {

--- a/src/components/Pagination/styled/pageButton.js
+++ b/src/components/Pagination/styled/pageButton.js
@@ -37,7 +37,7 @@ const StyledPageButton = styled.li`
             border-radius: 0;
         }
         :nth-child(1) > button {
-            border-radius: 100px 0 0 100px;
+            border-radius: 100px;
         }
 
         :nth-last-child(1) > button {


### PR DESCRIPTION
# `Fixed 🛠 Pagination Buttons`
## This PR fixes issue #1991 

fix: #1991 

## Changes proposed in this PR:
- Page Button shape fixed.
- If total pages are equal to one, then no arrow buttons are displayed.