### PR TITLE
docs: add variant bare on the Input documentation

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -134,7 +134,7 @@ Input.propTypes = {
     /** An object with custom style applied to the outer element. */
     style: PropTypes.object,
     /** The variant changes the appearance of the Input. Accepted variants include default,
-     * and shaded. This value defaults to default. */
+     *shaded and bare. This value defaults to default. */
     variant: PropTypes.oneOf(['default', 'shaded', 'bare']),
     /** The id of the outer element. */
     id: PropTypes.string,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #

## Changes proposed in this PR:
-add bare to the accepted values for variant on Input.js documentation

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
