### PR TITLE
docs: fix label  typo in sidebar component

### DIFF
--- a/src/components/Sidebar/readme.md
+++ b/src/components/Sidebar/readme.md
@@ -32,7 +32,7 @@ class SimpleSidebar extends React.Component {
         return (
             <Sidebar selectedItem={selectedItem} onSelect={this.handleOnSelect} id="sidebar-1">
                 <SidebarItem icon={<DashboardPurpleIcon />} name="Dashboard" label="Dashboard" />
-                <SidebarItem icon={<ApplicationIcon />} name="Aplications" label="Aplications" />
+                <SidebarItem icon={<ApplicationIcon />} name="Aplications" label="Applications" />
                 <SidebarItem icon={<PuzzleIcon />} name="Components" label="Components" />
                 <SidebarItem icon={<MessagesIcon />} name="Messages" label="Messages" />
                 <SidebarItem icon={<ChartsIcon />} name="Charts" label="Charts" />
@@ -90,7 +90,7 @@ function SimpleSidebar() {
             <div>
                 <Sidebar selectedItem={selectedItem} onSelect={handleOnSelect} id="sidebar-1">
                     <SidebarItem icon={<DashboardPurpleIcon />} name="Dashboard" label="Dashboard" />
-                    <SidebarItem icon={<ApplicationIcon />} name="Aplications" label="Aplications" />
+                    <SidebarItem icon={<ApplicationIcon />} name="Aplications" label="Applications" />
                     <SidebarItem icon={<PuzzleIcon />} name="Components" label="Components" />
                     <SidebarItem icon={<MessagesIcon />} name="Messages" label="Messages" />
                     <SidebarItem icon={<ChartsIcon />} name="Charts" label="Charts" />


### PR DESCRIPTION
Fix typo in the name of the label Applications, in the Sidebar component examples

<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #

## Changes proposed in this PR:
-

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
