### PR TITLE
fix: locale does not exist on WeekDayPicker

### DIFF
--- a/src/components/WeekDayPicker/index.d.ts
+++ b/src/components/WeekDayPicker/index.d.ts
@@ -13,6 +13,7 @@ export interface WeekDayPickerProps extends BaseProps {
     hideLabel?: boolean;
     bottomHelpText?: ReactNode;
     availableDates?: WeekDays[];
+    locale?: string;
     disabled?: boolean;
     required?: boolean;
     readOnly?: boolean;


### PR DESCRIPTION
fix: #2020

## Changes proposed in this PR:
- Add missing prop to index.d.ts

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
