### PR TITLE
feat: implement onMouseEnter and onMouseLeave props

### DIFF
--- a/src/components/Button/index.d.ts
+++ b/src/components/Button/index.d.ts
@@ -22,6 +22,8 @@ export interface ButtonProps extends BaseProps {
     onKeyDown?: (event: KeyboardEvent<HTMLElement>) => void;
     onFocus?: (event: FocusEvent<HTMLElement>) => void;
     onBlur?: (event: FocusEvent<HTMLElement>) => void;
+    onMouseEnter?: (event: MouseEvent<HTMLElement>) => void;
+    onMouseLeave?: (event: MouseEvent<HTMLElement>) => void;
     ariaHaspopup?: boolean;
     ariaControls?: string;
     ariaExpanded?: boolean;

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -58,6 +58,8 @@ export default class Button extends Component {
             onFocus,
             onBlur,
             onClick,
+            onMouseEnter,
+            onMouseLeave,
             title,
             type,
             ariaHaspopup,
@@ -87,6 +89,8 @@ export default class Button extends Component {
                 onFocus={onFocus}
                 onBlur={onBlur}
                 onClick={onClick}
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
                 title={title}
                 type={type}
                 aria-haspopup={ariaHaspopup}
@@ -145,6 +149,10 @@ Button.propTypes = {
     onFocus: PropTypes.func,
     /** The action triggered when the element releases focus. */
     onBlur: PropTypes.func,
+    /** The action triggered when moving the mouse pointer into the button. */
+    onMouseEnter: PropTypes.func,
+    /** The action triggered when moving the mouse pointer out of the button. */
+    onMouseLeave: PropTypes.func,
     /** Indicates that the element has a popup context menu or sub-level menu. */
     ariaHaspopup: PropTypes.bool,
     /** A space-separated list of element IDs that
@@ -180,6 +188,8 @@ Button.defaultProps = {
     onKeyDown: () => {},
     onFocus: () => {},
     onBlur: () => {},
+    onMouseEnter: () => {},
+    onMouseLeave: () => {},
     ariaHaspopup: undefined,
     className: undefined,
     style: undefined,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2025 

## Changes proposed in this PR:
-add onMouseEnter and onMouseLeave props to index.d.ts
-add PropTypes and defaultProps for onMouseEnter and onMouseLeave on index.js
-destructure onMouseEnter and onMouseLeave 
-use onMouseEnter and onMouseLeave


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
