### PR TITLE
fix: text color on GoogleAddressLookup when have a value and is disabled

### DIFF
--- a/src/components/Lookup/styled/selectedInput.js
+++ b/src/components/Lookup/styled/selectedInput.js
@@ -23,7 +23,6 @@ caret-color: transparent;
 
     &[disabled] {
         box-shadow: none;
-        color: ${props => props.palette.background.disabled};
 
         &:focus,
         &:active {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2034

## Changes proposed in this PR:
- remove wrong color when disabled

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
