### PR TITLE
fix: picklist when readonly and click the label it opens the menu

### DIFF
--- a/src/components/Picklist/__test__/picklist.spec.js
+++ b/src/components/Picklist/__test__/picklist.spec.js
@@ -132,4 +132,18 @@ describe('<Picklist />', () => {
         expect(component.find('[aria-expanded=true]').exists()).toBe(false);
         expect(component.find(InternalOverlay).prop('isVisible')).toBe(false);
     });
+    it('should not open menu when is readOnly and click the picklist label', () => {
+        const component = mount(
+            <Picklist label="Picklist" readOnly>
+                <PicklistOption label="Option 1" name="option1" />
+                <PicklistOption label="Option 2" name="option2" />
+                <PicklistOption label="Option 3" name="option3" />
+            </Picklist>,
+        );
+        expect(component.find('[aria-expanded=true]').exists()).toBe(false);
+        expect(component.find(InternalOverlay).prop('isVisible')).toBe(false);
+        component.find('label').simulate('click');
+        expect(component.find('[aria-expanded=true]').exists()).toBe(false);
+        expect(component.find(InternalOverlay).prop('isVisible')).toBe(false);
+    });
 });

--- a/src/components/Picklist/index.js
+++ b/src/components/Picklist/index.js
@@ -120,9 +120,12 @@ class Picklist extends Component {
     }
 
     openMenu() {
-        this.setState({
-            isOpen: true,
-        });
+        const { readOnly } = this.props;
+        if (!readOnly) {
+            this.setState({
+                isOpen: true,
+            });
+        }
     }
 
     closeMenu() {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2036 

## Changes proposed in this PR:
- fix: picklist when readOnly and click the label it opens the menu

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
