### PR TITLE
fix: styles in Picklist component when icon and readOnly is passed

### DIFF
--- a/src/components/Picklist/styled/input.js
+++ b/src/components/Picklist/styled/input.js
@@ -50,6 +50,12 @@ const PickerInput = attachThemeAttrs(styled(StyledInput))`
         padding-right: 0;
         outline: 0;
 
+        ${props.icon &&
+            `
+            border: 1px solid transparent;
+            padding-left: 2.35rem;
+        `};        
+
         &::-ms-expand {
             display: none;
         }
@@ -62,6 +68,12 @@ const PickerInput = attachThemeAttrs(styled(StyledInput))`
             box-shadow: none;
             border-color: transparent;
             background-color: transparent;
+
+            ${props.icon &&
+                `
+                border: 1px solid transparent;
+                padding-left: 2.35rem;
+            `}
         }
     `}
 `;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2035

## Changes proposed in this PR:
- fix: styles in Picklist component when icon and readOnly is passed

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
