### PR TITLE
fix: add divider to the Table header when is empty and the variant is…

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -423,7 +423,7 @@ export default class Table extends Component {
         const maxColWidth = Number(maxColumnWidth) || 5000;
 
         const isEmpty = data.length === 0;
-        const theme = { variant, hideTableHeader };
+        const theme = { variant, hideTableHeader, isEmpty };
 
         if (keyField && typeof keyField === 'string') {
             return (

--- a/src/components/Table/styled/thead.js
+++ b/src/components/Table/styled/thead.js
@@ -1,10 +1,25 @@
 import styled from 'styled-components';
+import attachThemeAttrs from '../../../styles/helpers/attachThemeAttrs';
 
-const StyledThead = styled.thead`
+const StyledThead = attachThemeAttrs(styled.thead)`
     ${props =>
         props.theme.hideTableHeader &&
         `
         visibility: hidden;
+    `};
+    ${props =>
+        props.theme.variant === 'listview' &&
+        props.theme.isEmpty &&
+        `
+            &::after {
+                content: '';
+                height: 1px;
+                width: 100%;
+                left: 0;
+                position: absolute;
+                background-color: ${props.palette.border.divider};
+                border-radius: 100px;
+            }
     `};
 `;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2080

## Changes proposed in this PR:
- add divider to the Table header when is empty and the variant is listview

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
