### PR TITLE
fix: add `component` prop on Option type definition

### DIFF
--- a/src/components/Option/index.d.ts
+++ b/src/components/Option/index.d.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ComponentType, ReactNode } from 'react';
 import { BaseProps, IconPosition } from '../types';
 
 export interface OptionProps extends BaseProps {
@@ -10,6 +10,7 @@ export interface OptionProps extends BaseProps {
     disabled?: boolean;
     title?: string;
     value?: any;
+    component?: ComponentType;
 }
 
 export default function(props: OptionProps): JSX.Element | null;


### PR DESCRIPTION
fix: #2115

## Changes proposed in this PR:
- Add `component` prop to Option typescript definition
-----
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).