### PR TITLE
fix: iconPosition does not exist on ButtonMenu

### DIFF
--- a/src/components/ButtonMenu/index.d.ts
+++ b/src/components/ButtonMenu/index.d.ts
@@ -3,7 +3,7 @@ import { BaseProps, ButtonIconVariant, ButtonIconSize, MenuSize, MenuAlignment }
 
 export interface ButtonMenuProps extends BaseProps {
     icon?: ReactNode;
-    iconPosition: string;
+    iconPosition?: string;
     children?: ReactNode;
     buttonVariant?: ButtonIconVariant;
     buttonSize?: ButtonIconSize;

--- a/src/components/ButtonMenu/index.d.ts
+++ b/src/components/ButtonMenu/index.d.ts
@@ -3,6 +3,7 @@ import { BaseProps, ButtonIconVariant, ButtonIconSize, MenuSize, MenuAlignment }
 
 export interface ButtonMenuProps extends BaseProps {
     icon?: ReactNode;
+    iconPosition: string;
     children?: ReactNode;
     buttonVariant?: ButtonIconVariant;
     buttonSize?: ButtonIconSize;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2106 

## Changes proposed in this PR:
- fix: iconPosition does not exist on ButtonMenu

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
