### PR TITLE
fix: buttonVariant neutral does not exist

### DIFF
--- a/src/components/Button/index.d.ts
+++ b/src/components/Button/index.d.ts
@@ -1,18 +1,10 @@
 import { ReactNode, MouseEvent, FocusEvent, KeyboardEvent, ComponentType } from 'react';
-import { BaseProps, ButtonType } from '../types';
+import { BaseProps, ButtonType, ButtonIconVariant } from '../types';
 
 export interface ButtonProps extends BaseProps {
     label?: ReactNode;
     children?: ReactNode;
-    variant?:
-        | 'base'
-        | 'neutral'
-        | 'brand'
-        | 'outline-brand'
-        | 'destructive'
-        | 'success'
-        | 'inverse'
-        | 'border-inverse';
+    variant?: ButtonIconVariant;
     shaded?: boolean;
     title?: string;
     type?: ButtonType;

--- a/src/components/types.d.ts
+++ b/src/components/types.d.ts
@@ -13,12 +13,15 @@ export type ButtonType = 'button' | 'submit' | 'reset';
 export type ButtonIconSize = 'xx-small' | 'x-small' | 'small' | 'medium' | 'large';
 export type ButtonIconVariant =
     | 'base'
+    | 'neutral'
     | 'brand'
+    | 'outline-brand'
+    | 'destructive'
     | 'success'
     | 'border'
     | 'border-filled'
-    | 'border-inverse'
-    | 'inverse';
+    | 'inverse'
+    | 'border-inverse';
 export type VisualPickerSize = 'small' | 'medium' | 'large';
 export type IconPosition = 'left' | 'right';
 export type LabelAlignment = 'left' | 'center' | 'right';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2107 

## Changes proposed in this PR:
- fix: buttonVariant 'neutral' does not exist

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
