### PR TITLE
fix: fixed TS definitions for Calendar, DatePicker, MultiSelect

### DIFF
--- a/src/components/Calendar/index.d.ts
+++ b/src/components/Calendar/index.d.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../types';
 
 export interface CalendarProps extends BaseProps {
     id?: string;
-    value?: string | Date;
+    value?: string | Date | Date[];
     maxDate?: Date;
     minDate?: Date;
     onChange?: (date: Date) => void;

--- a/src/components/DatePicker/index.d.ts
+++ b/src/components/DatePicker/index.d.ts
@@ -1,7 +1,7 @@
 import { ReactNode, MouseEvent, ComponentType } from 'react';
 import { BaseProps, LabelAlignment } from '../types';
 
-type Value = string | Date;
+type Value = string | Date | Date[];
 
 export interface DatePickerProps extends BaseProps {
     value?: Value;

--- a/src/components/MultiSelect/index.d.ts
+++ b/src/components/MultiSelect/index.d.ts
@@ -26,6 +26,7 @@ export interface MultiSelectProps extends BaseProps {
     onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
     onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
     children?: ReactNode;
+    showCheckbox?: Boolean;
 }
 
 export default function(props: MultiSelectProps): JSX.Element | null;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2149

## Changes proposed in this PR:
- Added typescript support for date ranges in Calendar, DatePicker. Added typescript support for the 'showCheckbox' prop on MultiSelect.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
