### PR TITLE
fix: set tab buttons to type button

### DIFF
--- a/src/components/Tab/__test__/tab.spec.js
+++ b/src/components/Tab/__test__/tab.spec.js
@@ -93,4 +93,9 @@ describe('<Tab />', () => {
         component.setProps({ name: 'tab-1' });
         expect(privateUpdateTabMockFn).toHaveBeenCalledTimes(0);
     });
+    it('should set type to "button" in button element', () => {
+        const component = mount(<Tab name="tab-1" activeTabName="tab-2" />);
+        const button = component.find('button');
+        expect(button.prop('type')).toBe('button');
+    });
 });

--- a/src/components/Tab/index.js
+++ b/src/components/Tab/index.js
@@ -77,6 +77,7 @@ class TabItem extends Component {
             >
                 <StyledButton
                     role="tab"
+                    type="button"
                     aria-selected={isActive}
                     onClick={this.handleSelect}
                     tabIndex={this.getTabIndex()}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2162 

## Changes proposed in this PR:
-

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
