### PR TITLE
docs: fix CarouselImage assistiveText prop in docs

### DIFF
--- a/src/components/CarouselCard/readme.md
+++ b/src/components/CarouselCard/readme.md
@@ -19,21 +19,21 @@ const carouselContainerStyles = {
                 src="images/illustrations/Illustration-rainbow-4.svg"
                 header="First Card"
                 description="First card description."
-                alternativeText="First card accessible description."
+                assistiveText="First card accessible description."
                 href="/#/Components/CarouselImage"
             />
             <CarouselImage
                 src="images/illustrations/Illustration-rainbow-3.svg"
                 header="Second Card"
                 description="Second card description."
-                alternativeText="Second card accessible description."
+                assistiveText="Second card accessible description."
                 href="/#/Components/CarouselImage"
             />
             <CarouselImage
                 src="images/illustrations/Illustration-rainbow-5.svg"
                 header="Third Card"
                 description="Third card description."
-                alternativeText="Third card accessible description."
+                assistiveText="Third card accessible description."
                 href="/#/Components/CarouselImage"
             />
         </CarouselCard>
@@ -77,7 +77,7 @@ class CarrouselCardExample extends React.Component {
                     src="images/illustrations/Illustration-rainbow-6.svg"
                     header="New Card"
                     description="New card description."
-                    alternativeText="New card accessible description."
+                    assistiveText="New card accessible description."
                     href="/#/Components/CarouselImage"
                 />
             );
@@ -107,7 +107,7 @@ class CarrouselCardExample extends React.Component {
                         src="images/illustrations/Illustration-rainbow-4.svg"
                         header="First Card"
                         description="First card description."
-                        alternativeText="First card accessible description."
+                        assistiveText="First card accessible description."
                         href="/#/Components/CarouselImage"
                     />
                     {this.renderNewCard()}
@@ -115,14 +115,14 @@ class CarrouselCardExample extends React.Component {
                         src="images/illustrations/Illustration-rainbow-3.svg"
                         header="Second Card"
                         description="Second card description."
-                        alternativeText="Second card accessible description."
+                        assistiveText="Second card accessible description."
                         href="/#/Components/CarouselImage"
                     />
                     <CarouselImage
                         src="images/illustrations/Illustration-rainbow-5.svg"
                         header="Third Card"
                         description="Third card description."
-                        alternativeText="Third card accessible description."
+                        assistiveText="Third card accessible description."
                         href="/#/Components/CarouselImage"
                     />
                 </CarouselCard>

--- a/src/components/CarouselImage/readme.md
+++ b/src/components/CarouselImage/readme.md
@@ -15,19 +15,19 @@ const carouselContainerStyles = {
                 src="images/illustrations/Illustration-rainbow-4.svg"
                 header="First Card"
                 description="First card description."
-                alternativeText="First card accessible description."
+                assistiveText="First card accessible description."
             />
             <CarouselImage
                 src="images/illustrations/Illustration-rainbow-3.svg"
                 header="Second Card"
                 description="Second card description."
-                alternativeText="Second card accessible description."
+                assistiveText="Second card accessible description."
             />
             <CarouselImage
                 src="images/illustrations/Illustration-rainbow-5.svg"
                 header="Third Card"
                 description="Third card description."
-                alternativeText="Third card accessible description."
+                assistiveText="Third card accessible description."
             />
         </CarouselCard>
     </div>
@@ -50,21 +50,21 @@ const carouselContainerStyles = {
                 src="images/illustrations/Illustration-rainbow-4.svg"
                 header="First Card"
                 description="First card description."
-                alternativeText="First card accessible description."
+                assistiveText="First card accessible description."
                 href="/#/Components/CarouselCard"
             />
             <CarouselImage
                 src="images/illustrations/Illustration-rainbow-3.svg"
                 header="Second Card"
                 description="Second card description."
-                alternativeText="Second card accessible description."
+                assistiveText="Second card accessible description."
                 href="/#/Components/CarouselCard"
             />
             <CarouselImage
                 src="images/illustrations/Illustration-rainbow-5.svg"
                 header="Third Card"
                 description="Third card description."
-                alternativeText="Third card accessible description."
+                assistiveText="Third card accessible description."
                 href="/#/Components/CarouselCard"
             />
         </CarouselCard>


### PR DESCRIPTION
fix: #2139

## Changes proposed in this PR:
- Change `alternativeText` prop to 'assistiveText` in CarouselImage examples
- Change `alternativeText` prop to 'assistiveText` in CarouselCard examples

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).