### PR TITLE
fix: add `isLoading` prop to `MultiSelect` component

### DIFF
--- a/src/components/MultiSelect/index.d.ts
+++ b/src/components/MultiSelect/index.d.ts
@@ -16,6 +16,7 @@ export interface MultiSelectProps extends BaseProps {
     required?: boolean;
     disabled?: boolean;
     readOnly?: boolean;
+    isLoading?: boolean;
     variant?: 'default' | 'chip' | 'bare';
     chipVariant?: 'base' | 'neutral' | 'outline-brand' | 'brand';
     isBare?: boolean;

--- a/src/components/MultiSelect/index.js
+++ b/src/components/MultiSelect/index.js
@@ -48,6 +48,7 @@ const MultiSelect = React.forwardRef((props, ref) => {
         variant,
         chipVariant,
         isBare,
+        isLoading,
         value,
         onChange,
         onFocus,
@@ -266,6 +267,7 @@ const MultiSelect = React.forwardRef((props, ref) => {
                         <StyledDropdown
                             id={dropdownId}
                             value={value}
+                            isLoading={isLoading}
                             onChange={handleChange}
                             ref={dropdownRef}
                             width={dropdownWidth}
@@ -313,6 +315,8 @@ MultiSelect.propTypes = {
     required: PropTypes.bool,
     /** Specifies that an input element should be disabled. This value defaults to false. */
     disabled: PropTypes.bool,
+    /** If is set to true, then is showed a loading symbol. */
+    isLoading: PropTypes.bool,
     /** Specifies that an input field is read-only. This value defaults to false. */
     readOnly: PropTypes.bool,
     /** Specifies the tab order of an element (when the tab button is used for navigating). */
@@ -354,6 +358,7 @@ MultiSelect.defaultProps = {
     required: false,
     disabled: false,
     readOnly: false,
+    isLoading: false,
     tabIndex: 0,
     variant: 'default',
     chipVariant: 'base',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2184 

## Changes proposed in this PR:
- add `isLoading` prop to `MultiSelect` component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
