### PR TITLE
fix: add type declaration to Label component

### DIFF
--- a/src/components/Input/label/index.d.ts
+++ b/src/components/Input/label/index.d.ts
@@ -1,0 +1,15 @@
+import { ComponentType, ReactNode } from 'react';
+
+export interface LabelProps {
+    className?: string;
+    label?: ReactNode;
+    required?: boolean;
+    inputId?: string;
+    readOnly?: boolean;
+    id?: string;
+    labelAlignment?: 'left' | 'center' | 'right';
+    hideLabel?: boolean;
+    as?: string;
+}
+
+export default function(props: LabelProps): JSX.Element | null;


### PR DESCRIPTION
## Changes proposed in this PR:
- Add type declaration to Label component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
