### PR TITLE
fix: add type declaration to useReduxForm

### DIFF
--- a/src/libs/hooks/useReduxForm.d.ts
+++ b/src/libs/hooks/useReduxForm.d.ts
@@ -1,0 +1,2 @@
+declare function useReduxForm<T>(props: T): Record<string, unknown>;
+export default useReduxForm;


### PR DESCRIPTION
## Changes proposed in this PR:
- add type declaration to useReduxForm

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).