### PR TITLE
fix: tree child InputCheckbox error

### DIFF
--- a/src/components/Tree/child.js
+++ b/src/components/Tree/child.js
@@ -101,7 +101,11 @@ export default function Child(props) {
                         onClick={handleNodeExpand}
                     />
                     <RenderIf isTrue={hasCheckbox}>
-                        <InputCheckbox checked={isChecked} onChange={handleNodeCheck} />
+                        <InputCheckbox
+                            label={label}
+                            checked={isChecked}
+                            onChange={handleNodeCheck}
+                        />
                     </RenderIf>
                 </InnerContainer>
                 <RenderIf isTrue={hasIcon}>


### PR DESCRIPTION
fix: #2178

## Changes proposed in this PR:
- Pass label to checkbox in Tree child

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
