### PR TITLE
fix: fix action cell overflow when table variant is listview

### DIFF
--- a/src/components/Table/body/styled/cellContainer.js
+++ b/src/components/Table/body/styled/cellContainer.js
@@ -37,6 +37,7 @@ const StyledCellContainer = attachThemeAttrs(styled.td)`
             border-bottom-right-radius: 12px;
             border-top-right-radius: 12px;
             overflow: hidden;
+            padding: 2px 0;
         }
     `}
 


### PR DESCRIPTION
## Changes proposed in this PR:
- Fix action cell overflow when table variant is listview

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
