### PR TITLE
feat: add `tooltip` prop to SidebarItem component

### DIFF
--- a/src/components/Sidebar/index.d.ts
+++ b/src/components/Sidebar/index.d.ts
@@ -7,6 +7,7 @@ export interface SidebarProps extends BaseProps {
     onSelect?: (event: MouseEvent<HTMLElement>, name: string) => void;
     ariaLabel?: string;
     children?: ReactNode;
+    hideSelectedItemIndicator?: boolean;
 }
 
 export default function(props: SidebarProps): JSX.Element | null;

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -56,7 +56,7 @@ Sidebar.propTypes = {
      * @ignore
      */
     children: PropTypes.node,
-    /** Controls if the selected item indicator should be hidden */
+    /** Controls if the selected item indicator should be hidden. */
     hideSelectedItemIndicator: PropTypes.bool,
 };
 

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -11,11 +11,21 @@ import StyledUl from './styled/ul';
  * @category Layout
  */
 export default function Sidebar(props) {
-    const { ariaLabel, style, selectedItem, onSelect, className, children, id } = props;
+    const {
+        ariaLabel,
+        style,
+        selectedItem,
+        onSelect,
+        className,
+        children,
+        id,
+        hideSelectedItemIndicator,
+    } = props;
 
     const context = {
         selectedItem,
         onSelect,
+        hideSelectedItemIndicator,
     };
 
     return (
@@ -46,6 +56,8 @@ Sidebar.propTypes = {
      * @ignore
      */
     children: PropTypes.node,
+    /** Controls if the selected item indicator should be hidden */
+    hideSelectedItemIndicator: PropTypes.bool,
 };
 
 Sidebar.defaultProps = {
@@ -56,4 +68,5 @@ Sidebar.defaultProps = {
     style: undefined,
     children: null,
     id: undefined,
+    hideSelectedItemIndicator: false,
 };

--- a/src/components/SidebarItem/__test__/sidebarItem.spec.js
+++ b/src/components/SidebarItem/__test__/sidebarItem.spec.js
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faClock, faUser } from '@fortawesome/free-solid-svg-icons';
 import Sidebar from '../../Sidebar';
 import SidebarItem from '../index';
+import InternalTooltip from '../../InternalTooltip';
 
 describe('<SidebarItem when href is passed />', () => {
     it('should have aria-current of page if isSelected', () => {
@@ -97,5 +98,21 @@ describe('<SidebarItem when href is not passed />', () => {
         const sidebarLink = component.find('button');
         sidebarLink.simulate('click');
         expect(component.find(FontAwesomeIcon).prop('icon')).toBe(faUser);
+    });
+});
+
+describe('<SidebarItem />', () => {
+    it('should render a tooltip when passed', () => {
+        const component = mount(
+            <Sidebar>
+                <SidebarItem
+                    icon={<FontAwesomeIcon icon={faClock} />}
+                    name="sidebaritem-test-2"
+                    label="sidebaritem-test-2"
+                    tooltip="sidebaritem-test-2"
+                />
+            </Sidebar>,
+        );
+        expect(component.find(InternalTooltip).exists()).toBe(true);
     });
 });

--- a/src/components/SidebarItem/index.d.ts
+++ b/src/components/SidebarItem/index.d.ts
@@ -8,6 +8,7 @@ export interface SidebarItemProps extends BaseProps {
     selectedIcon?: ReactNode;
     href?: string;
     onClick?: (event: MouseEvent<HTMLElement>) => void;
+    tooltip?: ReactNode;
 }
 
 export default function(props: SidebarItemProps): JSX.Element | null;

--- a/src/components/SidebarItem/index.js
+++ b/src/components/SidebarItem/index.js
@@ -56,11 +56,6 @@ function SidebarItem(props) {
             className={className}
             style={style}
             hideSelectedItemIndicator={hideSelectedItemIndicator}
-            ref={triggerRef}
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
-            onFocus={onFocus}
-            onBlur={onBlur}
         >
             <RenderIf isTrue={href}>
                 <StyledAnchorContent
@@ -69,6 +64,11 @@ function SidebarItem(props) {
                     onClick={handleOnClick}
                     aria-current={getAriaCurrent()}
                     isSelected={isSelected}
+                    ref={triggerRef}
+                    onMouseEnter={onMouseEnter}
+                    onMouseLeave={onMouseLeave}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
                 >
                     <ItemContent isSelected={isSelected} label={label} icon={currentIcon} />
                 </StyledAnchorContent>
@@ -79,6 +79,11 @@ function SidebarItem(props) {
                     onClick={handleOnClick}
                     aria-current={getAriaCurrent()}
                     isSelected={isSelected}
+                    ref={triggerRef}
+                    onMouseEnter={onMouseEnter}
+                    onMouseLeave={onMouseLeave}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
                 >
                     <ItemContent isSelected={isSelected} label={label} icon={currentIcon} />
                 </StyledButtonContent>

--- a/src/components/SidebarItem/index.js
+++ b/src/components/SidebarItem/index.js
@@ -1,8 +1,10 @@
 /* eslint-disable no-script-url, react/prop-types */
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { withContext } from '../Sidebar/context';
 import RenderIf from '../RenderIf';
+import InternalTooltip from '../InternalTooltip';
+import useDefaultTooltipConnector from '../InternalTooltip/hooks/useDefaultTooltipConnector';
 import StyledLi from './styled/li';
 import StyledAnchorContent from './styled/anchorContent';
 import StyledButtonContent from './styled/buttonContent';
@@ -22,9 +24,18 @@ function SidebarItem(props) {
         style,
         selectedItem,
         onSelect,
+        tooltip,
+        hideSelectedItemIndicator,
     } = props;
+    const triggerRef = useRef();
+    const tooltipRef = useRef();
     const isSelected = name === selectedItem;
     const currentIcon = isSelected && !!selectedIcon ? selectedIcon : icon;
+
+    const { onFocus, onBlur, onMouseEnter, onMouseLeave, isVisible } = useDefaultTooltipConnector({
+        tooltipRef,
+        triggerRef: () => triggerRef,
+    });
 
     const getAriaCurrent = () => {
         if (isSelected) {
@@ -33,7 +44,7 @@ function SidebarItem(props) {
         return undefined;
     };
 
-    function hanldeOnClick(event) {
+    function handleOnClick(event) {
         onClick(event);
         onSelect(event, name);
     }
@@ -44,12 +55,18 @@ function SidebarItem(props) {
             isSelected={isSelected}
             className={className}
             style={style}
+            hideSelectedItemIndicator={hideSelectedItemIndicator}
+            ref={triggerRef}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+            onFocus={onFocus}
+            onBlur={onBlur}
         >
             <RenderIf isTrue={href}>
                 <StyledAnchorContent
                     data-id="sidebar-item-clickable-element"
                     href={href}
-                    onClick={hanldeOnClick}
+                    onClick={handleOnClick}
                     aria-current={getAriaCurrent()}
                     isSelected={isSelected}
                 >
@@ -59,12 +76,22 @@ function SidebarItem(props) {
             <RenderIf isTrue={!href}>
                 <StyledButtonContent
                     data-id="sidebar-item-clickable-element"
-                    onClick={hanldeOnClick}
+                    onClick={handleOnClick}
                     aria-current={getAriaCurrent()}
                     isSelected={isSelected}
                 >
                     <ItemContent isSelected={isSelected} label={label} icon={currentIcon} />
                 </StyledButtonContent>
+            </RenderIf>
+            <RenderIf isTrue={tooltip}>
+                <InternalTooltip
+                    triggerElementRef={() => triggerRef}
+                    isVisible={isVisible}
+                    preferredPosition="right"
+                    ref={tooltipRef}
+                >
+                    {tooltip}
+                </InternalTooltip>
             </RenderIf>
         </StyledLi>
     );
@@ -89,6 +116,8 @@ SidebarItem.propTypes = {
     className: PropTypes.string,
     /** An object with custom style applied for the outer element. */
     style: PropTypes.object,
+    /** A tooltip to show on hover */
+    tooltip: PropTypes.node,
 };
 
 SidebarItem.defaultProps = {
@@ -100,6 +129,7 @@ SidebarItem.defaultProps = {
     onClick: () => {},
     className: undefined,
     style: undefined,
+    tooltip: undefined,
 };
 
 export default withContext(SidebarItem);

--- a/src/components/SidebarItem/readme.md
+++ b/src/components/SidebarItem/readme.md
@@ -49,6 +49,57 @@ class SimpleSidebar extends React.Component {
     </div>
 ```
 
+##### SidebarItem with tooltip
+
+```js
+import React from 'react';
+import { Sidebar, SidebarItem } from 'react-rainbow-components';
+import styled from 'styled-components';
+
+const SideBarContainer = styled.div.attrs(props => {
+    return props.theme.rainbow.palette;
+})`
+    background: ${props => props.background.main};
+    width: 100px;
+    border-bottom-left-radius: 0.875rem;
+`;
+
+class SimpleSidebar extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            selectedItem: 'GettingStarted',
+        };
+        this.handleOnSelect = this.handleOnSelect.bind(this);
+    }
+
+    handleOnSelect(event, selectedItem) {
+        return this.setState({ selectedItem });
+    }
+
+    render() {
+        const { selectedItem } = this.state;
+
+        return (
+            <Sidebar selectedItem={selectedItem} onSelect={this.handleOnSelect} id="sidebar-1">
+                <SidebarItem icon={<DashboardPurpleIcon />} name="Dashboard" tooltip="Dashboard" />
+                <SidebarItem icon={<ApplicationIcon />} name="Aplications" tooltip="Aplications" />
+                <SidebarItem icon={<PuzzleIcon />} name="Components" tooltip="Components" />
+                <SidebarItem icon={<MessagesIcon />} name="Messages" tooltip="Messages" />
+                <SidebarItem icon={<ChartsIcon />} name="Charts" tooltip="Charts" />
+            </Sidebar>
+        );
+    }
+}
+
+    <div>
+        <GlobalHeader src="images/user/user3.jpg" />
+        <SideBarContainer className="rainbow-p-top_small rainbow-p-bottom_medium">
+            <SimpleSidebar />
+        </SideBarContainer>
+    </div>
+```
+
 ##### SidebarItem with selectedIcon
 
 ```js

--- a/src/components/SidebarItem/readme.md
+++ b/src/components/SidebarItem/readme.md
@@ -52,7 +52,7 @@ class SimpleSidebar extends React.Component {
 ##### SidebarItem with tooltip
 
 ```js
-import React from 'react';
+import React, { useState } from 'react';
 import { Sidebar, SidebarItem } from 'react-rainbow-components';
 import styled from 'styled-components';
 
@@ -64,38 +64,28 @@ const SideBarContainer = styled.div.attrs(props => {
     border-bottom-left-radius: 0.875rem;
 `;
 
-class SimpleSidebar extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            selectedItem: 'GettingStarted',
-        };
-        this.handleOnSelect = this.handleOnSelect.bind(this);
+const SidebarWithTooltip = () => {
+    const [selectedItem, setSelectedItem] = useState();
+
+    const handleOnSelect = (event, newSelectedItem) => {
+        setSelectedItem(newSelectedItem);
     }
 
-    handleOnSelect(event, selectedItem) {
-        return this.setState({ selectedItem });
-    }
-
-    render() {
-        const { selectedItem } = this.state;
-
-        return (
-            <Sidebar selectedItem={selectedItem} onSelect={this.handleOnSelect} id="sidebar-1">
-                <SidebarItem icon={<DashboardPurpleIcon />} name="Dashboard" tooltip="Dashboard" />
-                <SidebarItem icon={<ApplicationIcon />} name="Aplications" tooltip="Aplications" />
-                <SidebarItem icon={<PuzzleIcon />} name="Components" tooltip="Components" />
-                <SidebarItem icon={<MessagesIcon />} name="Messages" tooltip="Messages" />
-                <SidebarItem icon={<ChartsIcon />} name="Charts" tooltip="Charts" />
-            </Sidebar>
-        );
-    }
-}
+    return (
+        <Sidebar selectedItem={selectedItem} onSelect={handleOnSelect} id="sidebar-3">
+            <SidebarItem icon={<DashboardPurpleIcon />} name="Dashboard" tooltip="Dashboard" />
+            <SidebarItem icon={<ApplicationIcon />} name="Aplications" tooltip="Aplications" />
+            <SidebarItem icon={<PuzzleIcon />} name="Components" tooltip="Components" />
+            <SidebarItem icon={<MessagesIcon />} name="Messages" tooltip="Messages" />
+            <SidebarItem icon={<ChartsIcon />} name="Charts" tooltip="Charts" />
+        </Sidebar>
+    )
+};
 
     <div>
         <GlobalHeader src="images/user/user3.jpg" />
         <SideBarContainer className="rainbow-p-top_small rainbow-p-bottom_medium">
-            <SimpleSidebar />
+            <SidebarWithTooltip />
         </SideBarContainer>
     </div>
 ```
@@ -132,7 +122,7 @@ class SimpleSidebar extends React.Component {
         const { selectedItem } = this.state;
 
         return (
-            <Sidebar selectedItem={selectedItem} onSelect={this.handleOnSelect} id="sidebar-3">
+            <Sidebar selectedItem={selectedItem} onSelect={this.handleOnSelect} id="sidebar-5">
                 <SidebarItem
                     icon={<HomeBorderIcon />}
                     selectedIcon={<HomeFilledIcon />}

--- a/src/components/SidebarItem/styled/li.js
+++ b/src/components/SidebarItem/styled/li.js
@@ -15,6 +15,7 @@ const StyledLi = attachThemeAttrs(styled.li)`
     }
 
     ${props =>
+        !props.hideSelectedItemIndicator &&
         props.isSelected &&
         `
             ::before {


### PR DESCRIPTION
## Changes proposed in this PR:
- add `tooltip` prop to SidebarItem
- add `hideSelectedItemIndicator` prop to Sidebar

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
