### PR TITLE
fix: improve Sidebar tooltip

### DIFF
--- a/src/components/InternalTooltip/styled/index.js
+++ b/src/components/InternalTooltip/styled/index.js
@@ -10,7 +10,7 @@ const StyledTooltip = attachThemeAttrs(styled.div)`
     z-index: 1;
     opacity: 0;
     transition-property: opacity;
-    transition-duration: 1s;
+    transition-duration: 250ms;
     box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
     width: auto;
     

--- a/src/components/SidebarItem/index.js
+++ b/src/components/SidebarItem/index.js
@@ -32,7 +32,7 @@ function SidebarItem(props) {
     const isSelected = name === selectedItem;
     const currentIcon = isSelected && !!selectedIcon ? selectedIcon : icon;
 
-    const { onFocus, onBlur, onMouseEnter, onMouseLeave, isVisible } = useDefaultTooltipConnector({
+    const { onMouseEnter, onMouseLeave, isVisible } = useDefaultTooltipConnector({
         tooltipRef,
         triggerRef: () => triggerRef,
     });
@@ -67,8 +67,6 @@ function SidebarItem(props) {
                     ref={triggerRef}
                     onMouseEnter={onMouseEnter}
                     onMouseLeave={onMouseLeave}
-                    onFocus={onFocus}
-                    onBlur={onBlur}
                 >
                     <ItemContent isSelected={isSelected} label={label} icon={currentIcon} />
                 </StyledAnchorContent>
@@ -82,8 +80,6 @@ function SidebarItem(props) {
                     ref={triggerRef}
                     onMouseEnter={onMouseEnter}
                     onMouseLeave={onMouseLeave}
-                    onFocus={onFocus}
-                    onBlur={onBlur}
                 >
                     <ItemContent isSelected={isSelected} label={label} icon={currentIcon} />
                 </StyledButtonContent>


### PR DESCRIPTION
## Changes proposed in this PR:
- Removed tooltip when a SidebarItem is focused
- Reduced tooltip fade animation to 250ms

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).