### PR TITLE
fix: remove title from AccordionSection label

### DIFF
--- a/src/components/AccordionSection/index.js
+++ b/src/components/AccordionSection/index.js
@@ -151,7 +151,7 @@ class AccordionItem extends Component {
                             <StyledIcon>{icon}</StyledIcon>
                         </RenderIf>
                         <RenderIf isTrue={label}>
-                            <StyledSpan title="Accordion Label">{label}</StyledSpan>
+                            <StyledSpan data-id="accordion-section-label">{label}</StyledSpan>
                         </RenderIf>
                     </StyledHeading>
                 </StyledSummary>

--- a/src/components/AccordionSection/pageObject/index.js
+++ b/src/components/AccordionSection/pageObject/index.js
@@ -51,7 +51,7 @@ class PageAccordionSection {
      */
     getLabel() {
         return $(this.rootElement)
-            .$('[title="Accordion Label"]')
+            .$('[data-id="accordion-section-label"]')
             .getText();
     }
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Remove hard coded title from AccordionSection label

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).