### PR TITLE
fix: add `getNode` to tree interface

### DIFF
--- a/src/components/Tree/index.d.ts
+++ b/src/components/Tree/index.d.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import { BaseProps } from '../types';
 
 interface selectValue {
@@ -26,4 +26,9 @@ export interface TreeProps extends BaseProps {
     ariaLabel?: string;
 }
 
-export default function(props: TreeProps): JSX.Element | null;
+interface Tree {
+    (props: TreeProps): ReactElement<any, any> | null;
+    getNode?: (tree: DataItem[], nodePath: number[]) => DataItem;
+}
+
+export default Tree;


### PR DESCRIPTION
## Changes proposed in this PR:
- Add `getNode` to tree interface

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
