### PR TITLE
fix: fix InternalDropdown search when label is not a string

### DIFF
--- a/src/components/InternalDropdown/helpers/searchFilter.js
+++ b/src/components/InternalDropdown/helpers/searchFilter.js
@@ -14,7 +14,7 @@ export default function filterCollection(params) {
         query,
         data,
         mapValuesToStringFn = item =>
-            typeof item.label === 'string' ? item.label : item.ref.textContent,
+            typeof item.label === 'string' ? item.label : item.labelText,
     } = params;
     if (query) {
         return data.filter(item => {

--- a/src/components/InternalDropdown/helpers/searchFilter.js
+++ b/src/components/InternalDropdown/helpers/searchFilter.js
@@ -10,7 +10,12 @@ function getWords(query) {
 }
 
 export default function filterCollection(params) {
-    const { query, data, mapValuesToStringFn = item => item.label } = params;
+    const {
+        query,
+        data,
+        mapValuesToStringFn = item =>
+            typeof item.label === 'string' ? item.label : item.ref.textContent,
+    } = params;
     if (query) {
         return data.filter(item => {
             const stringToMatch = mapValuesToStringFn(item);

--- a/src/components/InternalDropdown/helpers/searchFilter.js
+++ b/src/components/InternalDropdown/helpers/searchFilter.js
@@ -14,7 +14,7 @@ export default function filterCollection(params) {
         query,
         data,
         mapValuesToStringFn = item =>
-            typeof item.label === 'string' ? item.label : item.labelText,
+            typeof item.label === 'string' ? item.label : item.searchableText,
     } = params;
     if (query) {
         return data.filter(item => {

--- a/src/components/Option/index.d.ts
+++ b/src/components/Option/index.d.ts
@@ -3,6 +3,7 @@ import { BaseProps, IconPosition } from '../types';
 
 export interface OptionProps extends BaseProps {
     label?: string;
+    labelText?: string;
     name?: string | number;
     variant?: 'default' | 'header';
     icon?: ReactNode;

--- a/src/components/Option/index.d.ts
+++ b/src/components/Option/index.d.ts
@@ -3,7 +3,7 @@ import { BaseProps, IconPosition } from '../types';
 
 export interface OptionProps extends BaseProps {
     label?: ReactNode;
-    labelText?: string;
+    searchableText?: string;
     name?: string | number;
     variant?: 'default' | 'header';
     icon?: ReactNode;

--- a/src/components/Option/index.d.ts
+++ b/src/components/Option/index.d.ts
@@ -2,7 +2,7 @@ import { ComponentType, ReactNode } from 'react';
 import { BaseProps, IconPosition } from '../types';
 
 export interface OptionProps extends BaseProps {
-    label?: string;
+    label?: ReactNode;
     labelText?: string;
     name?: string | number;
     variant?: 'default' | 'header';

--- a/src/components/Option/index.js
+++ b/src/components/Option/index.js
@@ -273,7 +273,7 @@ export { OptionItem };
 
 Option.propTypes = {
     /** Text of the PicklistOption. */
-    label: PropTypes.string,
+    label: PropTypes.node,
     /** Searchable text when label is a node */
     labelText: PropTypes.string,
     /** The name of the PicklistOption. */

--- a/src/components/Option/index.js
+++ b/src/components/Option/index.js
@@ -95,13 +95,21 @@ class OptionItem extends Component {
     }
 
     register() {
-        const { privateRegisterChild, label, labelText, name, icon, value, variant } = this.props;
+        const {
+            privateRegisterChild,
+            label,
+            searchableText,
+            name,
+            icon,
+            value,
+            variant,
+        } = this.props;
 
         if (privateRegisterChild) {
             return setTimeout(() => {
                 return privateRegisterChild(this.itemRef.current, {
                     label,
-                    labelText,
+                    searchableText,
                     name,
                     icon,
                     value,
@@ -275,7 +283,7 @@ Option.propTypes = {
     /** Text of the PicklistOption. */
     label: PropTypes.node,
     /** Searchable text when label is a node */
-    labelText: PropTypes.string,
+    searchableText: PropTypes.string,
     /** The name of the PicklistOption. */
     name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /** The variant changes the type of PicklistOption.
@@ -306,7 +314,7 @@ Option.propTypes = {
 
 Option.defaultProps = {
     label: undefined,
-    labelText: undefined,
+    searchableText: undefined,
     name: undefined,
     variant: 'default',
     icon: null,

--- a/src/components/Option/index.js
+++ b/src/components/Option/index.js
@@ -95,12 +95,13 @@ class OptionItem extends Component {
     }
 
     register() {
-        const { privateRegisterChild, label, name, icon, value, variant } = this.props;
+        const { privateRegisterChild, label, labelText, name, icon, value, variant } = this.props;
 
         if (privateRegisterChild) {
             return setTimeout(() => {
                 return privateRegisterChild(this.itemRef.current, {
                     label,
+                    labelText,
                     name,
                     icon,
                     value,
@@ -273,6 +274,8 @@ export { OptionItem };
 Option.propTypes = {
     /** Text of the PicklistOption. */
     label: PropTypes.string,
+    /** Searchable text when label is a node */
+    labelText: PropTypes.string,
     /** The name of the PicklistOption. */
     name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     /** The variant changes the type of PicklistOption.
@@ -303,6 +306,7 @@ Option.propTypes = {
 
 Option.defaultProps = {
     label: undefined,
+    labelText: undefined,
     name: undefined,
     variant: 'default',
     icon: null,

--- a/src/components/PicklistOption/index.d.ts
+++ b/src/components/PicklistOption/index.d.ts
@@ -3,7 +3,7 @@ import { BaseProps, IconPosition } from '../types';
 
 export interface PicklistOptionProps extends BaseProps {
     label?: ReactNode;
-    labelText?: string;
+    searchableText?: string;
     name?: string;
     variant?: 'default' | 'header';
     icon?: ReactNode;

--- a/src/components/PicklistOption/index.d.ts
+++ b/src/components/PicklistOption/index.d.ts
@@ -2,7 +2,8 @@ import { ReactNode } from 'react';
 import { BaseProps, IconPosition } from '../types';
 
 export interface PicklistOptionProps extends BaseProps {
-    label?: string;
+    label?: ReactNode;
+    labelText?: string;
     name?: string;
     variant?: 'default' | 'header';
     icon?: ReactNode;

--- a/src/components/PicklistOption/index.js
+++ b/src/components/PicklistOption/index.js
@@ -15,7 +15,7 @@ PicklistOption.propTypes = {
     /** Text of the PicklistOption. */
     label: PropTypes.node,
     /** Searchable text when label is a node */
-    labelText: PropTypes.string,
+    searchableText: PropTypes.string,
     /** The name of the PicklistOption. */
     name: PropTypes.string,
     /** The variant changes the type of PicklistOption.
@@ -41,7 +41,7 @@ PicklistOption.propTypes = {
 
 PicklistOption.defaultProps = {
     label: undefined,
-    labelText: undefined,
+    searchableText: undefined,
     name: undefined,
     variant: 'default',
     icon: null,

--- a/src/components/PicklistOption/index.js
+++ b/src/components/PicklistOption/index.js
@@ -13,7 +13,9 @@ export default function PicklistOption(props) {
 
 PicklistOption.propTypes = {
     /** Text of the PicklistOption. */
-    label: PropTypes.string,
+    label: PropTypes.node,
+    /** Searchable text when label is a node */
+    labelText: PropTypes.string,
     /** The name of the PicklistOption. */
     name: PropTypes.string,
     /** The variant changes the type of PicklistOption.
@@ -39,6 +41,7 @@ PicklistOption.propTypes = {
 
 PicklistOption.defaultProps = {
     label: undefined,
+    labelText: undefined,
     name: undefined,
     variant: 'default',
     icon: null,


### PR DESCRIPTION
## Changes proposed in this PR:
- Fix InternalDropdown search when item label is not a string

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
