### PR TITLE
feat: add top to `labelAlignment` prop on CheckboxToggle

### DIFF
--- a/src/components/CheckboxToggle/index.d.ts
+++ b/src/components/CheckboxToggle/index.d.ts
@@ -11,7 +11,7 @@ export interface CheckboxToggleProps extends BaseProps {
     onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
     onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
     id?: string;
-    labelAlignment?: 'left' | 'right';
+    labelAlignment?: 'left' | 'right' | 'top';
 }
 
 declare const CheckboxToggle: ComponentType<CheckboxToggleProps>;

--- a/src/components/CheckboxToggle/index.js
+++ b/src/components/CheckboxToggle/index.js
@@ -121,7 +121,7 @@ CheckboxToggle.propTypes = {
     id: PropTypes.string,
     /** Describes the position of the Toggle label. Options include left and right.
      * This value defaults to right. */
-    labelAlignment: PropTypes.oneOf(['left', 'right']),
+    labelAlignment: PropTypes.oneOf(['left', 'right', 'top']),
 };
 
 CheckboxToggle.defaultProps = {

--- a/src/components/CheckboxToggle/index.js
+++ b/src/components/CheckboxToggle/index.js
@@ -119,7 +119,7 @@ CheckboxToggle.propTypes = {
     style: PropTypes.object,
     /** The id of the outer element. */
     id: PropTypes.string,
-    /** Describes the position of the Toggle label. Options include left and right.
+    /** Describes the position of the Toggle label. Options include top, left and right.
      * This value defaults to right. */
     labelAlignment: PropTypes.oneOf(['left', 'right', 'top']),
 };

--- a/src/components/CheckboxToggle/readme.md
+++ b/src/components/CheckboxToggle/readme.md
@@ -110,3 +110,28 @@ class DisabledCheckboxToggle extends React.Component {
         <DisabledCheckboxToggle />
     </div>
 ```
+
+##### checkbox with label alignment
+```js
+import React from 'react';
+import { CheckboxToggle } from 'react-rainbow-components';
+
+const AlignedCheckboxToggle = () => (<>
+    <CheckboxToggle
+        label="Align left"
+        labelAlignment="left"
+    />
+    <CheckboxToggle
+        label="Align top"
+        labelAlignment="top"
+    />
+    <CheckboxToggle
+        label="Align right"
+        labelAlignment="right"
+    />
+</>);
+
+    <div className="rainbow-p-vertical_large rainbow-p-horizontal_x-large rainbow-flex rainbow-justify_space-around">
+        <AlignedCheckboxToggle />
+    </div>
+```

--- a/src/components/CheckboxToggle/styled/label.js
+++ b/src/components/CheckboxToggle/styled/label.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import attachThemeAttrs from '../../../styles/helpers/attachThemeAttrs';
 import { FONT_SIZE_TEXT_MEDIUM } from '../../../styles/fontSizes';
-import { MARGIN_SMALL } from '../../../styles/margins';
+import { MARGIN_SMALL, MARGIN_XX_SMALL } from '../../../styles/margins';
 
 const StyledLabel = attachThemeAttrs(styled.span)`
     color: ${props => props.palette.text.main};
@@ -12,6 +12,13 @@ const StyledLabel = attachThemeAttrs(styled.span)`
         props.labelAlignment === 'left' &&
         `
             margin-right: 12px;
+        `};
+
+    ${props =>
+        props.labelAlignment === 'top' &&
+        `
+            margin-left: 0;
+            margin-bottom: ${MARGIN_XX_SMALL};
         `};
 `;
 

--- a/src/components/CheckboxToggle/styled/labelContainer.js
+++ b/src/components/CheckboxToggle/styled/labelContainer.js
@@ -1,6 +1,7 @@
 /* stylelint-disable no-descending-specificity, max-line-length */
 import styled from 'styled-components';
 import attachThemeAttrs from '../../../styles/helpers/attachThemeAttrs';
+import { MARGIN_MEDIUM } from '../../../styles/margins';
 
 const StyledLabelContainer = attachThemeAttrs(styled.label)`
     display: inline-flex;
@@ -126,7 +127,8 @@ const StyledLabelContainer = attachThemeAttrs(styled.label)`
         props.labelAlignment === 'top' &&
         `
             flex-direction: column-reverse;
-            align-items: center;
+            align-items: start;
+            padding-left: ${MARGIN_MEDIUM};
         `};
     
 

--- a/src/components/CheckboxToggle/styled/labelContainer.js
+++ b/src/components/CheckboxToggle/styled/labelContainer.js
@@ -1,7 +1,6 @@
 /* stylelint-disable no-descending-specificity, max-line-length */
 import styled from 'styled-components';
 import attachThemeAttrs from '../../../styles/helpers/attachThemeAttrs';
-import { MARGIN_MEDIUM } from '../../../styles/margins';
 
 const StyledLabelContainer = attachThemeAttrs(styled.label)`
     display: inline-flex;
@@ -128,7 +127,6 @@ const StyledLabelContainer = attachThemeAttrs(styled.label)`
         `
             flex-direction: column-reverse;
             align-items: start;
-            padding-left: ${MARGIN_MEDIUM};
         `};
     
 

--- a/src/components/CheckboxToggle/styled/labelContainer.js
+++ b/src/components/CheckboxToggle/styled/labelContainer.js
@@ -121,6 +121,15 @@ const StyledLabelContainer = attachThemeAttrs(styled.label)`
         `
             flex-direction: row-reverse;
         `};
+
+    ${props =>
+        props.labelAlignment === 'top' &&
+        `
+            flex-direction: column-reverse;
+            align-items: center;
+        `};
+    
+
 `;
 
 export default StyledLabelContainer;


### PR DESCRIPTION
## Changes proposed in this PR:
- Add top to `labelAlignment` prop on CheckboxToggle component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
