### PR TITLE
fix: add `id` prop to StripeCardInput component

### DIFF
--- a/src/components/StripeCardInput/index.d.ts
+++ b/src/components/StripeCardInput/index.d.ts
@@ -25,6 +25,7 @@ export interface StripeCardEvent {
 }
 
 export interface StripeCardInput extends BaseProps {
+    id?: string;
     apiKey: string;
     label?: ReactNode;
     labelAlignment?: LabelAlignment;

--- a/src/components/StripeCardInput/index.js
+++ b/src/components/StripeCardInput/index.js
@@ -17,6 +17,7 @@ import StyledCardInput from './styled/cardInput';
  */
 const StripeCardInput = React.forwardRef((props, ref) => {
     const {
+        id,
         apiKey,
         label,
         labelAlignment,
@@ -83,6 +84,7 @@ const StripeCardInput = React.forwardRef((props, ref) => {
 
     return (
         <StyledContainer
+            id={id}
             ref={ref}
             className={className}
             style={style}
@@ -110,6 +112,8 @@ const StripeCardInput = React.forwardRef((props, ref) => {
 });
 
 StripeCardInput.propTypes = {
+    /** The id of the outer element. */
+    id: PropTypes.string,
     /** The application's API key. To use Stripe,
      * you must get an API Key. See https://dashboard.stripe.com/account/apikeys
      * to get an API Key. */
@@ -177,6 +181,7 @@ StripeCardInput.propTypes = {
 };
 
 StripeCardInput.defaultProps = {
+    id: undefined,
     label: undefined,
     labelAlignment: 'center',
     hideLabel: false,


### PR DESCRIPTION
## Changes proposed in this PR:
- Added id prop to StripeCardInput component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
