### PR TITLE
fix: move document event listeners to capture phase

### DIFF
--- a/src/components/Table/head/resizeBar.js
+++ b/src/components/Table/head/resizeBar.js
@@ -21,8 +21,8 @@ export default class ResizeBar extends Component {
     handleMouseUp(event) {
         event.preventDefault();
         const { onResize } = this.props;
-        document.removeEventListener('mouseup', this.handleMouseUp);
-        document.removeEventListener('mousemove', this.handleMouseMove);
+        document.removeEventListener('mouseup', this.handleMouseUp, { capture: true });
+        document.removeEventListener('mousemove', this.handleMouseMove, { capture: true });
         onResize(this.newXPosition);
         this.setState({
             resizeBarStyle: { willChange: 'transform' },
@@ -52,8 +52,8 @@ export default class ResizeBar extends Component {
         event.preventDefault();
         this.newXPosition = 0;
         this.startXPosition = event.clientX;
-        document.addEventListener('mousemove', this.handleMouseMove);
-        document.addEventListener('mouseup', this.handleMouseUp);
+        document.addEventListener('mousemove', this.handleMouseMove, { capture: true });
+        document.addEventListener('mouseup', this.handleMouseUp, { capture: true });
     }
 
     render() {

--- a/src/libs/outsideClick/index.js
+++ b/src/libs/outsideClick/index.js
@@ -15,7 +15,7 @@ class OutsideClick {
         if (!containerRef || !callback) return;
         this.containerRef = containerRef;
         this.callback = callback;
-        document.addEventListener('click', this[privateHandleClick]);
+        document.addEventListener('click', this[privateHandleClick], { capture: true });
         this.listening = true;
     }
 
@@ -23,7 +23,7 @@ class OutsideClick {
         if (!this.listening) return;
 
         this.listening = false;
-        document.removeEventListener('click', this[privateHandleClick]);
+        document.removeEventListener('click', this[privateHandleClick], { capture: true });
         this.containerRef = null;
         this.callback = null;
     }

--- a/src/libs/scrollController/index.js
+++ b/src/libs/scrollController/index.js
@@ -18,7 +18,7 @@ const isIosDevice =
     /iP(ad|hone|od)/.test(window.navigator.platform);
 
 const eventOptions = { capture: true };
-const passiveEventOptions = { passive: true, capture: true };
+const passiveEventOptions = { passive: false, capture: true };
 
 let locks = [];
 let documentListenerAdded = false;

--- a/src/libs/scrollController/index.js
+++ b/src/libs/scrollController/index.js
@@ -17,6 +17,9 @@ const isIosDevice =
     window.navigator.platform &&
     /iP(ad|hone|od)/.test(window.navigator.platform);
 
+const eventOptions = { capture: true };
+const passiveEventOptions = { passive: true, capture: true };
+
 let locks = [];
 let documentListenerAdded = false;
 let initialClientY = -1;
@@ -165,7 +168,7 @@ export function disableBodyScroll(targetElement, options) {
                 document.addEventListener(
                     'touchmove',
                     preventDefault,
-                    hasPassiveEvents ? { passive: false } : undefined,
+                    hasPassiveEvents ? passiveEventOptions : eventOptions,
                 );
                 documentListenerAdded = true;
             }
@@ -193,7 +196,7 @@ export function clearAllBodyScrollLocks() {
             document.removeEventListener(
                 'touchmove',
                 preventDefault,
-                hasPassiveEvents ? { passive: false } : undefined,
+                hasPassiveEvents ? passiveEventOptions : eventOptions,
             );
             documentListenerAdded = false;
         }
@@ -227,7 +230,7 @@ export function enableBodyScroll(targetElement) {
             document.removeEventListener(
                 'touchmove',
                 preventDefault,
-                hasPassiveEvents ? { passive: false } : undefined,
+                hasPassiveEvents ? passiveEventOptions : eventOptions,
             );
 
             documentListenerAdded = false;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2276 

## Changes proposed in this PR:
- Move all event listeners on document to the capture phase

See [here](https://es.reactjs.org/blog/2020/10/20/react-v17.html#changes-to-event-delegation) and [here](https://es.reactjs.org/blog/2020/08/10/react-v17-rc.html#fixing-potential-issues) for explanation.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
