### PR TITLE
feat: add description prop to options on RadioGroup and CheckboxGroup components

### DIFF
--- a/integration/specs/CheckboxGroup/checkboxGroup-1.spec.js
+++ b/integration/specs/CheckboxGroup/checkboxGroup-1.spec.js
@@ -31,7 +31,7 @@ describe('CheckboxGroup base example', () => {
         const checkboxGroup = new PageCheckboxGroup(CHECKBOX_GROUP);
         const checkbox = checkboxGroup.getItem(0);
         checkbox.click();
-        // TODO: Use constant once PR merged
+        // TODO: Use constant once PR merged.
         browser.keys('Tab');
         expect(checkbox.hasFocus()).toBe(false);
     });

--- a/integration/specs/CheckboxGroup/checkboxGroup-1.spec.js
+++ b/integration/specs/CheckboxGroup/checkboxGroup-1.spec.js
@@ -31,7 +31,8 @@ describe('CheckboxGroup base example', () => {
         const checkboxGroup = new PageCheckboxGroup(CHECKBOX_GROUP);
         const checkbox = checkboxGroup.getItem(0);
         checkbox.click();
-        browser.keys(TAB_KEY);
+        // TODO: Use constant once PR merged
+        browser.keys('Tab');
         expect(checkbox.hasFocus()).toBe(false);
     });
     it('should set the checked on the checkbox clicked', () => {
@@ -61,8 +62,9 @@ describe('CheckboxGroup base example', () => {
         const checkbox1 = checkboxGroup.getItem(0);
         const checkbox2 = checkboxGroup.getItem(1);
         checkbox1.click();
-        browser.keys(TAB_KEY);
-        browser.keys(SPACE_KEY);
+        // TODO: Use constant once PR merged
+        browser.keys('Tab');
+        browser.keys('Space');
         expect(checkbox2.isChecked()).toBe(true);
     });
 });

--- a/integration/specs/RadioGroup/radioGroup-1.spec.js
+++ b/integration/specs/RadioGroup/radioGroup-1.spec.js
@@ -1,5 +1,4 @@
 const PageRadioGroup = require('../../../src/components/RadioGroup/pageObject');
-const { ARROW_DOWN_KEY } = require('../../constants');
 
 const RADIO_GROUP = '#radio-group-component-1';
 
@@ -23,7 +22,8 @@ describe('RadioGroup base example', () => {
         const radioGroup = new PageRadioGroup(RADIO_GROUP);
         const radio = radioGroup.getItem(1);
         radio.click();
-        browser.keys(ARROW_DOWN_KEY);
+        // TODO: Use constant once PR merged
+        browser.keys('ArrowDown');
         expect(radio.hasFocus()).toBe(false);
     });
     it('should focus the next item when press arrow down', () => {
@@ -31,7 +31,8 @@ describe('RadioGroup base example', () => {
         const radio1 = radioGroup.getItem(1);
         const radio2 = radioGroup.getItem(2);
         radio1.click();
-        browser.keys(ARROW_DOWN_KEY);
+        // TODO: Use constant once PR merged
+        browser.keys('ArrowDown');
         expect(radio2.hasFocus()).toBe(true);
     });
     it('should check the item clicked', () => {
@@ -44,7 +45,8 @@ describe('RadioGroup base example', () => {
         const radioGroup = new PageRadioGroup(RADIO_GROUP);
         const radio = radioGroup.getItem(1);
         radio.click();
-        browser.keys(ARROW_DOWN_KEY);
+        // TODO: Use constant once PR merged
+        browser.keys('ArrowDown');
         expect(radio.isChecked()).toBe(false);
     });
     it('should check the next item when press arrow down', () => {
@@ -52,7 +54,8 @@ describe('RadioGroup base example', () => {
         const radio1 = radioGroup.getItem(1);
         const radio2 = radioGroup.getItem(2);
         radio1.click();
-        browser.keys(ARROW_DOWN_KEY);
+        // TODO: Use constant once PR merged
+        browser.keys('ArrowDown');
         expect(radio2.isChecked()).toBe(true);
     });
 });

--- a/src/components/CheckboxGroup/checkboxList.js
+++ b/src/components/CheckboxGroup/checkboxList.js
@@ -13,7 +13,7 @@ export default function CheckboxList(props) {
         const { description, ...rest } = option;
 
         return (
-            <StyledItemContainer>
+            <StyledItemContainer data-id="input-checkboxgroup_container">
                 <Checkbox
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...rest}

--- a/src/components/CheckboxGroup/checkboxList.js
+++ b/src/components/CheckboxGroup/checkboxList.js
@@ -2,23 +2,32 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import isOptionSelected from './isOptionSelected';
 import Checkbox from '../Input/inputCheckbox/checkbox';
+import StyledItemContainer from '../RadioGroup/styled/itemContainer';
+import StyledItemDescription from '../RadioGroup/styled/itemDescription';
+import RenderIf from '../RenderIf';
 
 export default function CheckboxList(props) {
     const { values, options, onChange, describedBy, name, error } = props;
     return options.map((option, index) => {
         const key = `checkbox-${index}`;
+        const { description, ...rest } = option;
 
         return (
-            <Checkbox
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                {...option}
-                checked={isOptionSelected(values, option)}
-                onChange={onChange}
-                ariaDescribedBy={describedBy}
-                key={key}
-                name={name}
-                error={error}
-            />
+            <StyledItemContainer>
+                <Checkbox
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...rest}
+                    checked={isOptionSelected(values, option)}
+                    onChange={onChange}
+                    ariaDescribedBy={describedBy}
+                    key={key}
+                    name={name}
+                    error={error}
+                />
+                <RenderIf isTrue={description}>
+                    <StyledItemDescription>{description}</StyledItemDescription>
+                </RenderIf>
+            </StyledItemContainer>
         );
     });
 }

--- a/src/components/CheckboxGroup/index.d.ts
+++ b/src/components/CheckboxGroup/index.d.ts
@@ -5,6 +5,7 @@ interface Option {
     label?: ReactNode;
     value?: string;
     disabled?: boolean;
+    description?: string;
 }
 
 export interface CheckboxGroupProps extends BaseProps {

--- a/src/components/CheckboxGroup/index.js
+++ b/src/components/CheckboxGroup/index.js
@@ -98,6 +98,7 @@ CheckboxGroup.propTypes = {
             label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
             value: PropTypes.string,
             disabled: PropTypes.bool,
+            description: PropTypes.string,
         }),
     ),
     /** Text label for the checkbox group. */

--- a/src/components/CheckboxGroup/pageObject/index.js
+++ b/src/components/CheckboxGroup/pageObject/index.js
@@ -23,8 +23,9 @@ class PageCheckboxGroup {
         const items = $(this.rootElement).$$('[data-id="input-checkbox_container"]');
         if (items[itemPosition]) {
             return new PageCheckboxItem(
-                `${this.rootElement} [data-id="input-checkbox_container"]:nth-child(${itemPosition +
-                    1})`,
+                `${
+                    this.rootElement
+                } [data-id="input-checkboxgroup_container"]:nth-child(${itemPosition + 1})`,
             );
         }
         return null;

--- a/src/components/CheckboxGroup/readme.md
+++ b/src/components/CheckboxGroup/readme.md
@@ -303,3 +303,33 @@ const CheckboxGroupTry = () => {
         <CheckboxGroupTry />
     </div>;
 ```
+
+##### Checkbox Group with description
+
+```js
+import React, { useState } from 'react';
+import { CheckboxGroup } from 'react-rainbow-components';
+
+const options = [
+    { value: 'checkboxOne', label: 'Checkbox One', disabled: false, description: 'Checkbox One Description' },
+    { value: 'checkboxTwo', label: 'Checkbox Two', disabled: false, description: 'Checkbox Two Description' },
+    { value: 'checkboxThree', label: 'Checkbox Three', disabled: false, description: 'Checkbox Three Description' },
+];
+
+const DescriptionCheckboxGroup = () => {
+    const [values, setValues] = useState([]);
+
+    return (
+        <CheckboxGroup
+            id="checkbox-group-1"
+            options={options}
+            value={values}
+            onChange={setValues}
+            label="Checkbox Group Label"
+        />
+    );
+}
+    <div className="rainbow-p-vertical_large rainbow-p-left_xx-large">
+        <DescriptionCheckboxGroup />
+    </div>;
+```

--- a/src/components/RadioGroup/index.js
+++ b/src/components/RadioGroup/index.js
@@ -95,6 +95,7 @@ RadioGroup.propTypes = {
             label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
             value: PropTypes.string,
             disabled: PropTypes.bool,
+            description: PropTypes.string,
         }),
     ),
     /** Specifies that an radio group must be filled out before submitting the form. */

--- a/src/components/RadioGroup/pageObject/index.js
+++ b/src/components/RadioGroup/pageObject/index.js
@@ -23,8 +23,9 @@ class PageRadioGroup {
         const items = $(this.rootElement).$$('[data-id="input-radio_container"]');
         if (items[itemPosition]) {
             return new PageRadioItem(
-                `${this.rootElement} [data-id="input-radio_container"]:nth-child(${itemPosition +
-                    1})`,
+                `${
+                    this.rootElement
+                } [data-id="input-radiogroup_container"]:nth-child(${itemPosition + 1})`,
             );
         }
         return null;

--- a/src/components/RadioGroup/radioItems.js
+++ b/src/components/RadioGroup/radioItems.js
@@ -14,7 +14,7 @@ export default function RadioItems(props) {
         const key = `radio-${index}`;
         const { description, ...rest } = option;
         return (
-            <StyledItemContainer>
+            <StyledItemContainer data-id="input-radiogroup_container">
                 <Radio
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...rest}

--- a/src/components/RadioGroup/radioItems.js
+++ b/src/components/RadioGroup/radioItems.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Radio from '../Input/inputRadio/radio';
+import StyledItemContainer from './styled/itemContainer';
+import RenderIf from '../RenderIf';
+import StyledItemDescription from './styled/itemDescription';
 
 export default function RadioItems(props) {
     const { options, ariaDescribedby, onChange, value, name, error } = props;
@@ -9,17 +12,23 @@ export default function RadioItems(props) {
 
     return options.map((option, index) => {
         const key = `radio-${index}`;
+        const { description, ...rest } = option;
         return (
-            <Radio
-                // eslint-disable-next-line react/jsx-props-no-spreading
-                {...option}
-                key={key}
-                onChange={onChange}
-                checked={isChecked(option)}
-                ariaDescribedby={ariaDescribedby}
-                name={name}
-                error={error}
-            />
+            <StyledItemContainer>
+                <Radio
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...rest}
+                    key={key}
+                    onChange={onChange}
+                    checked={isChecked(option)}
+                    ariaDescribedby={ariaDescribedby}
+                    name={name}
+                    error={error}
+                />
+                <RenderIf isTrue={description}>
+                    <StyledItemDescription>{description}</StyledItemDescription>
+                </RenderIf>
+            </StyledItemContainer>
         );
     });
 }

--- a/src/components/RadioGroup/readme.md
+++ b/src/components/RadioGroup/readme.md
@@ -208,3 +208,38 @@ const SimpleRadioGroup = () => {
         <SimpleRadioGroup />
     </div>
 ```
+
+##### radio group with description
+
+```js
+import React, { useState } from 'react';
+import { RadioGroup } from 'react-rainbow-components';
+
+const options = [
+    { value: 'radioOne', label: 'Radio One', description: 'Radio One Description' },
+    { value: 'radioTwo', label: 'Radio Two', description: 'Radio Two Description' },
+    { value: 'radioThree', label: 'Radio Three', description: 'Radio Three Description' },
+];
+
+const DescriptionRadioGroup = () => {
+    const [value, setValue] = useState('anonymous');
+
+    const handleOnChange = event => {
+        setValue(event.target.value);
+    }
+
+    return (
+        <RadioGroup
+            id="radio-group-component-1"
+            options={options}
+            value={value}
+            onChange={handleOnChange}
+            label="Radio Group Label"
+        />
+    );
+}
+
+    <div className="rainbow-p-vertical_large rainbow-p-left_xx-large">
+        <DescriptionRadioGroup />
+    </div>
+```

--- a/src/components/RadioGroup/styled/itemContainer.js
+++ b/src/components/RadioGroup/styled/itemContainer.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const StyledItemContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+export default StyledItemContainer;

--- a/src/components/RadioGroup/styled/itemDescription.js
+++ b/src/components/RadioGroup/styled/itemDescription.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+import attachThemeAttrs from '../../../styles/helpers/attachThemeAttrs';
+import { lighten } from '../../../styles/helpers/color';
+
+const StyledItemDescription = attachThemeAttrs(styled.span)`
+    color: ${props => lighten(props.palette.text.label, 0.2)};
+    display: inline-block;
+    margin-left: 2rem;
+`;
+
+export default StyledItemDescription;

--- a/src/components/RadioGroup/styled/itemDescription.js
+++ b/src/components/RadioGroup/styled/itemDescription.js
@@ -1,11 +1,14 @@
 import styled from 'styled-components';
 import attachThemeAttrs from '../../../styles/helpers/attachThemeAttrs';
 import { lighten } from '../../../styles/helpers/color';
+import { MARGIN_SMALL } from '../../../styles/margins';
 
 const StyledItemDescription = attachThemeAttrs(styled.span)`
     color: ${props => lighten(props.palette.text.label, 0.2)};
     display: inline-block;
     margin-left: 2rem;
+    line-height: 1em;
+    margin-bottom: ${MARGIN_SMALL};
 `;
 
 export default StyledItemDescription;

--- a/src/components/types.d.ts
+++ b/src/components/types.d.ts
@@ -36,4 +36,5 @@ export interface RadioOption {
     label?: ReactNode;
     value?: string;
     disabled?: boolean;
+    description?: string;
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Add description prop to RadioGroup options
- Add description prop to CheckboxGroup options

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
