### PR TITLE
fix: set type button to AccordionSection summary

### DIFF
--- a/src/components/AccordionSection/__test__/accordionSection.spec.js
+++ b/src/components/AccordionSection/__test__/accordionSection.spec.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import AccordionSection from '..';
+
+describe('<AccordionSection/>', () => {
+    it('should have type button on section summary', () => {
+        const component = mount(<AccordionSection label="Test section" />);
+        expect(component.find('button').prop('type')).toBe('button');
+    });
+});

--- a/src/components/AccordionSection/index.js
+++ b/src/components/AccordionSection/index.js
@@ -142,6 +142,7 @@ class AccordionItem extends Component {
                     onKeyDown={this.handleKeyPressed}
                     aria-controls={this.accordionDetailsId}
                     aria-expanded={isExpanded}
+                    type="button"
                     ref={this.buttonRef}
                 >
                     <RightArrow isExpanded={isExpanded} disabled={disabled} />


### PR DESCRIPTION

## Changes proposed in this PR:
- Add type button to the AccordionSection summary

#### Related: nexxtway/rainbow-modules#471

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
