### PR TITLE
fix: update RadioGroup item styles when disabled

### DIFF
--- a/src/components/RadioGroup/index.js
+++ b/src/components/RadioGroup/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import withReduxForm from '../../libs/hocs/withReduxForm';
-import RadioItmes from './radioItems';
+import RadioItems from './radioItems';
 import RenderIf from '../RenderIf';
 import { uniqueId } from '../../libs/utils';
 import StyledFieldset from './styled/fieldset';
@@ -56,7 +56,7 @@ class RadioGroup extends Component {
                     />
                 </RenderIf>
                 <StyledContentContainer orientation={orientation}>
-                    <RadioItmes
+                    <RadioItems
                         value={value}
                         onChange={onChange}
                         options={options}

--- a/src/components/RadioGroup/radioItems.js
+++ b/src/components/RadioGroup/radioItems.js
@@ -12,7 +12,7 @@ export default function RadioItems(props) {
 
     return options.map((option, index) => {
         const key = `radio-${index}`;
-        const { description, ...rest } = option;
+        const { description, disabled, ...rest } = option;
         return (
             <StyledItemContainer data-id="input-radiogroup_container">
                 <Radio
@@ -24,9 +24,10 @@ export default function RadioItems(props) {
                     ariaDescribedby={ariaDescribedby}
                     name={name}
                     error={error}
+                    disabled={disabled}
                 />
                 <RenderIf isTrue={description}>
-                    <StyledItemDescription>{description}</StyledItemDescription>
+                    <StyledItemDescription disabled={disabled}>{description}</StyledItemDescription>
                 </RenderIf>
             </StyledItemContainer>
         );

--- a/src/components/RadioGroup/readme.md
+++ b/src/components/RadioGroup/readme.md
@@ -218,7 +218,7 @@ import { RadioGroup } from 'react-rainbow-components';
 const options = [
     { value: 'radioOne', label: 'Radio One', description: 'Radio One Description' },
     { value: 'radioTwo', label: 'Radio Two', description: 'Radio Two Description' },
-    { value: 'radioThree', label: 'Radio Three', description: 'Radio Three Description' },
+    { value: 'radioThree', label: 'Radio Three', description: 'Radio Three Description', disabled: true },
 ];
 
 const DescriptionRadioGroup = () => {

--- a/src/components/RadioGroup/styled/itemDescription.js
+++ b/src/components/RadioGroup/styled/itemDescription.js
@@ -9,6 +9,7 @@ const StyledItemDescription = attachThemeAttrs(styled.span)`
     margin-left: 2rem;
     line-height: 1em;
     margin-bottom: ${MARGIN_SMALL};
+    ${props => props.disabled && `color: ${props.palette.text.disabled};`};
 `;
 
 export default StyledItemDescription;


### PR DESCRIPTION
## Changes proposed in this PR:
- Updated RadioGroup item description text color when disabled

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
