### PR TITLE
fix: add padding top to MarkdownOutput

### DIFF
--- a/src/components/MarkdownOutput/renderers/styled.js
+++ b/src/components/MarkdownOutput/renderers/styled.js
@@ -23,11 +23,14 @@ const fontSizesMap = {
 
 export const StyledHeading = attachThemeAttrs(styled.h1)`
     font-size: ${props => fontSizesMap[props.level] || FONT_SIZE_HEADING_XX_SMALL};
-    margin-top: 1.25rem;
     margin-bottom: 0.75rem;
 
     b, strong {
         font-family: 'Lato Bold', Arial, Helvetica, sans-serif;
+    }
+
+    :not(:first-child) {
+        margin-top: 1.25rem;
     }
 `;
 

--- a/src/components/MarkdownOutput/renderers/styled.js
+++ b/src/components/MarkdownOutput/renderers/styled.js
@@ -23,14 +23,11 @@ const fontSizesMap = {
 
 export const StyledHeading = attachThemeAttrs(styled.h1)`
     font-size: ${props => fontSizesMap[props.level] || FONT_SIZE_HEADING_XX_SMALL};
+    margin-top: 1.25rem;
     margin-bottom: 0.75rem;
 
     b, strong {
         font-family: 'Lato Bold', Arial, Helvetica, sans-serif;
-    }
-
-    :not(:first-child) {
-        margin-top: 1.25rem;
     }
 `;
 

--- a/src/components/MarkdownOutput/styled/index.js
+++ b/src/components/MarkdownOutput/styled/index.js
@@ -6,6 +6,7 @@ const StyledContainer = attachThemeAttrs(styled.div)`
     font-size: ${FONT_SIZE_TEXT_LARGE};
     color: ${props => props.palette.text.main};
     line-height: 1.5;
+    padding-top: 1rem;
 
     .task-list-item {
         list-style: none;

--- a/src/components/MarkdownOutput/styled/index.js
+++ b/src/components/MarkdownOutput/styled/index.js
@@ -6,7 +6,6 @@ const StyledContainer = attachThemeAttrs(styled.div)`
     font-size: ${FONT_SIZE_TEXT_LARGE};
     color: ${props => props.palette.text.main};
     line-height: 1.5;
-    padding-top: 1rem;
 
     .task-list-item {
         list-style: none;
@@ -22,6 +21,10 @@ const StyledContainer = attachThemeAttrs(styled.div)`
             display: inline;
         }
     `}
+
+    > div > *:first-child {
+        margin-top: 0;
+    }
 `;
 
 export default StyledContainer;


### PR DESCRIPTION
## Changes proposed in this PR:
- Added paddinng to the top of the MarkdownOutput component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
