### PR TITLE
fix: close Picklist on viewport resize

### DIFF
--- a/src/components/Picklist/__test__/picklist.spec.js
+++ b/src/components/Picklist/__test__/picklist.spec.js
@@ -182,4 +182,15 @@ describe('<Picklist />', () => {
         component.find('input').simulate('click');
         expect(mockStopListening).toHaveBeenCalled();
     });
+    it('should cancel the resize listener when unmounted', () => {
+        const component = mount(
+            <Picklist label="Picklist">
+                <PicklistOption label="Option 1" name="option1" />
+                <PicklistOption label="Option 2" name="option2" />
+                <PicklistOption label="Option 3" name="option3" />
+            </Picklist>,
+        );
+        component.unmount();
+        expect(mockStopListening).toHaveBeenCalled();
+    });
 });

--- a/src/components/Picklist/__test__/picklist.spec.js
+++ b/src/components/Picklist/__test__/picklist.spec.js
@@ -12,7 +12,6 @@ import {
 import { Component as Picklist } from '..';
 import PicklistOption from '../../PicklistOption';
 import InternalOverlay from '../../InternalOverlay';
-import WindowResize from '../../../libs/WindowResize';
 
 jest.mock('../../InternalOverlay', () =>
     // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/components/Picklist/index.js
+++ b/src/components/Picklist/index.js
@@ -90,7 +90,7 @@ class Picklist extends Component {
     componentWillUnmount() {
         this.outsideClick.stopListening();
         this.windowScrolling.stopListening();
-        this.windowScrolling.stopListening();
+        this.windowResize.stopListening();
     }
 
     getErrorMessageId() {

--- a/src/components/Picklist/index.js
+++ b/src/components/Picklist/index.js
@@ -17,6 +17,7 @@ import StyledError from '../Input/styled/errorText';
 import StyledIndicator from './styled/indicator';
 import InternalDropdown from '../InternalDropdown';
 import InternalOverlay from '../InternalOverlay';
+import WindowResize from '../../libs/WindowResize';
 
 function positionResolver(opts) {
     const { trigger, viewport, content } = opts;
@@ -56,8 +57,10 @@ class Picklist extends Component {
         this.handleContainerClick = this.handleContainerClick.bind(this);
         this.closeAndFocusInput = this.closeAndFocusInput.bind(this);
         this.handleWindowScroll = this.handleWindowScroll.bind(this);
+        this.handleWindowResize = this.handleWindowResize.bind(this);
         this.outsideClick = new OutsideClick();
         this.windowScrolling = new WindowScrolling();
+        this.windowResize = new WindowResize();
         this.activeChildren = [];
         this.state = {
             isOpen: false,
@@ -80,11 +83,13 @@ class Picklist extends Component {
                 }
             });
             this.windowScrolling.startListening(this.handleWindowScroll);
+            this.windowResize.startListening(this.handleWindowResize);
         }
     }
 
     componentWillUnmount() {
         this.outsideClick.stopListening();
+        this.windowScrolling.stopListening();
         this.windowScrolling.stopListening();
     }
 
@@ -115,6 +120,10 @@ class Picklist extends Component {
         this.closeMenu();
     }
 
+    handleWindowResize() {
+        this.closeMenu();
+    }
+
     closeAndFocusInput() {
         this.closeMenu();
         this.focus();
@@ -132,6 +141,7 @@ class Picklist extends Component {
     closeMenu() {
         this.outsideClick.stopListening();
         this.windowScrolling.stopListening();
+        this.windowResize.stopListening();
         this.setState({
             isOpen: false,
         });

--- a/src/libs/WindowResize/index.js
+++ b/src/libs/WindowResize/index.js
@@ -1,0 +1,20 @@
+export default class WindowResize {
+    constructor() {
+        this.callback = null;
+        this.listening = false;
+    }
+
+    startListening(callback) {
+        this.callback = callback;
+        window.addEventListener('resize', this.callback);
+        this.listening = true;
+    }
+
+    stopListening() {
+        if (this.listening) {
+            this.listening = false;
+            window.removeEventListener('resize', this.callback);
+            this.callback = null;
+        }
+    }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Close Picklist when window is resized

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
