### PR TITLE
fix: improve ButtonMenu and HelpText dropdowns

### DIFF
--- a/src/components/HelpText/index.js
+++ b/src/components/HelpText/index.js
@@ -1,5 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useWindowScrolling } from '@rainbow-modules/hooks';
 import { useUniqueIdentifier, useDisclosure, useWindowResize } from '../../libs/hooks';
 import InternalOverlay from '../InternalOverlay';
 import RenderIf from '../RenderIf';
@@ -59,6 +60,8 @@ export default function HelpText(props) {
     }, [closeOverlay, isFocused, openOverlay]);
 
     useWindowResize(() => closeOverlay(), isOpen);
+
+    useWindowScrolling(closeOverlay, isOpen);
 
     const handleBlur = () => {
         if (!isClickTooltip.current) {

--- a/src/components/HelpText/index.js
+++ b/src/components/HelpText/index.js
@@ -83,7 +83,7 @@ export default function HelpText(props) {
 
     const handleTooltipMouseUp = () => {
         isClickTooltip.current = false;
-        triggerRef.current.focus();
+        setTimeout(() => triggerRef.current.focus());
     };
 
     const handleTooltipMouseEnter = () => {

--- a/src/components/PrimitiveMenu/index.js
+++ b/src/components/PrimitiveMenu/index.js
@@ -1,5 +1,6 @@
 import React, { useRef, useImperativeHandle, useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { useWindowScrolling } from '@rainbow-modules/hooks';
 import {
     useDisclosure,
     useOutsideClick,
@@ -42,6 +43,7 @@ const PrimitiveMenu = React.forwardRef((props, ref) => {
         isOpen,
     );
     useWindowResize(() => closeMenu(), isOpen);
+    useWindowScrolling(closeMenu, isOpen);
 
     useImperativeHandle(ref, () => ({
         focus: () => {


### PR DESCRIPTION
## Changes proposed in this PR:
- Close ButtonMenu on scroll
- Close HelpText on scroll
- Fix Button first click not working inside HelpText tooltip

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).