### PR TITLE
fix: close ZoomableImage on Escape key

### DIFF
--- a/src/components/ZoomableImage/__test__/zoomedImage.spec.js
+++ b/src/components/ZoomableImage/__test__/zoomedImage.spec.js
@@ -15,4 +15,14 @@ describe('<ZoomableImage />', () => {
         jest.runAllTimers();
         expect(close).toHaveBeenCalled();
     });
+
+    it('should close when Escape key is pressed', () => {
+        const close = jest.fn();
+        const component = mount(
+            <ZoomedImage src="https://via.placeholder.com/450" originalRect={{}} close={close} />,
+        );
+        component.find(StyledCenteredImage).simulate('keydown', { key: 'Escape' });
+        jest.runAllTimers();
+        expect(close).toHaveBeenCalled();
+    });
 });

--- a/src/components/ZoomableImage/zoomedImage.js
+++ b/src/components/ZoomableImage/zoomedImage.js
@@ -7,9 +7,23 @@ import getTransform from './helpers/getTransform';
 const ZoomedImage = ({ src, alt, close, originalRect }) => {
     const [isCentered, setIsCentered] = useState(false);
 
+    const handleKeyDown = event => {
+        if (event.key === 'Escape') {
+            setIsCentered(false);
+            setTimeout(close, 300);
+        }
+    };
+
     useEffect(() => {
         setIsCentered(true);
     }, []);
+
+    useEffect(() => {
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    });
 
     const handleClick = () => {
         setIsCentered(false);
@@ -17,7 +31,7 @@ const ZoomedImage = ({ src, alt, close, originalRect }) => {
     };
 
     return ReactDOM.createPortal(
-        <StyledImageContainer onClick={handleClick}>
+        <StyledImageContainer onClick={handleClick} onKeyDown={handleKeyDown}>
             <StyledBackdrop isCentered={isCentered} />
             <StyledCenteredImage
                 src={src}

--- a/src/components/ZoomableImage/zoomedImage.js
+++ b/src/components/ZoomableImage/zoomedImage.js
@@ -31,7 +31,7 @@ const ZoomedImage = ({ src, alt, close, originalRect }) => {
     };
 
     return ReactDOM.createPortal(
-        <StyledImageContainer onClick={handleClick} onKeyDown={handleKeyDown}>
+        <StyledImageContainer onClick={handleClick}>
             <StyledBackdrop isCentered={isCentered} />
             <StyledCenteredImage
                 src={src}


### PR DESCRIPTION
## Changes proposed in this PR:
- Close ZoomableImage when press Escape key

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
