### PR TITLE
fix: close ColorInput picker on scroll

### DIFF
--- a/src/components/ColorInput/index.js
+++ b/src/components/ColorInput/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-unused-prop-types */
 import React, { useState, useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { useScrollingIntent } from '@rainbow-modules/hooks';
 import Label from '../Input/label';
 import StyledContainer from '../Input/styled/container';
 import InternalOverlay from '../InternalOverlay';
@@ -107,6 +108,12 @@ const ColorInput = props => {
         },
         isOpen,
     );
+    useScrollingIntent({
+        callback: () => setIsOpen(false),
+        isListening: isOpen,
+        triggerElementRef: () => triggerRef,
+        threshold: 5,
+    });
     useWindowResize(() => setIsOpen(false), isOpen);
 
     const onBlur = useCallback(() => {


### PR DESCRIPTION
## Changes proposed in this PR:
- Close ColorInput picker on scroll

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).