### PR TITLE
fix: remove arrows from number inputs on mozilla in ColorPicker

### DIFF
--- a/src/components/ColorPicker/commons/rgba/styled.js
+++ b/src/components/ColorPicker/commons/rgba/styled.js
@@ -24,6 +24,10 @@ const StyledNumberInput = styled(Input)`
         appearance: none;
         margin: 0;
     }
+
+    input[type='number'] {
+        -moz-appearance: textfield;
+    }
 `;
 
 export default StyledNumberInput;


### PR DESCRIPTION
## Changes proposed in this PR:
- Remove up and down arrows from number inputs in the ColorPicker on Firefox.

[x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).