### PR TITLE
fix: fix MonthlyCalendar not rendering days

### DIFF
--- a/src/components/MonthlyCalendar/month.js
+++ b/src/components/MonthlyCalendar/month.js
@@ -7,9 +7,9 @@ export default function Month(props) {
     const { firstDayMonth, selectedDate, minDate, maxDate, onSelectDate } = props;
     let date = new Date(firstDayMonth);
     const lastDayMonth = useMemo(() => getLastDayMonth(firstDayMonth), [firstDayMonth]);
+    const weeks = [];
 
     function Weeks() {
-        const weeks = [];
         const dayOfWeek = date.getDay();
         const daysAfter = 6 - dayOfWeek;
         while (date <= lastDayMonth || addDays(date, -dayOfWeek) <= lastDayMonth) {


### PR DESCRIPTION
## Changes proposed in this PR:
- Fixed MonthlyCalendar not rendering days on some project configurations

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).