### PR TITLE
fix: remove font-family from active VerticalItem

### DIFF
--- a/src/components/VerticalItem/styled/anchor.js
+++ b/src/components/VerticalItem/styled/anchor.js
@@ -26,7 +26,7 @@ const StyledAnchor = attachThemeAttrs(styled.a)`
 
     :focus,
     :active {
-        font-family: 'Lato Black', Arial, sans-serif;
+        font-weight: bold;
         background-color: ${props => props.palette.action.active};
     }
 
@@ -39,7 +39,7 @@ const StyledAnchor = attachThemeAttrs(styled.a)`
         `
             color: ${props.palette.text.main};
             background-color: ${props.palette.action.active};
-            font-family: 'Lato Black', Arial, sans-serif;
+            font-weight: bold;
         `};
 `;
 

--- a/src/components/VerticalItem/styled/button.js
+++ b/src/components/VerticalItem/styled/button.js
@@ -28,7 +28,7 @@ const StyledAnchor = attachThemeAttrs(styled.button)`
 
     :focus,
     :active {
-        font-family: 'Lato Black', Arial, sans-serif;
+        font-weight: bold;
         background-color: ${props => props.palette.action.active};
     }
 
@@ -41,7 +41,7 @@ const StyledAnchor = attachThemeAttrs(styled.button)`
         `
             color: ${props.palette.text.main};
             background-color: ${props.palette.action.active};
-            font-family: 'Lato Black', Arial, sans-serif;
+            font-weight: bold;
         `};
 `;
 


### PR DESCRIPTION
fix: #2193 

## Changes proposed in this PR:
- Remove font-family from VerticalItem when active.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).