### PR TITLE
fix: hide RequiredAsterisk when there is no label

### DIFF
--- a/src/components/Input/label/__test__/label.spec.js
+++ b/src/components/Input/label/__test__/label.spec.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import Label from '..';
 import LabelText from '../labelText';
 import HiddenElement from '../../../Structural/hiddenElement';
+import RequiredAsterisk from '../../../RequiredAsterisk';
 
 describe('<InputBaseLabel/>', () => {
     describe('without hideLabel', () => {
@@ -26,6 +27,10 @@ describe('<InputBaseLabel/>', () => {
             const component = mount(<Label label="Input Label" />);
             expect(component.find(LabelText).exists()).toBe(true);
             expect(component.find(HiddenElement).exists()).toBe(false);
+        });
+        it('should not render the RequiredAsterisk when there is no label', () => {
+            const component = mount(<Label required />);
+            expect(component.find(RequiredAsterisk).exists()).toBe(false);
         });
     });
     describe('with hideLabel', () => {

--- a/src/components/Input/label/index.js
+++ b/src/components/Input/label/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import RequiredAsterisk from '../../RequiredAsterisk';
 import HiddenElement from '../../Structural/hiddenElement';
 import LabelText from './labelText';
+import RenderIf from '../../RenderIf';
 
 export default function Label(props) {
     const {
@@ -27,18 +28,20 @@ export default function Label(props) {
     }
 
     return (
-        <LabelText
-            className={className}
-            readOnly={readOnly}
-            labelAlignment={labelAlignment}
-            htmlFor={inputId}
-            as={as}
-            id={id}
-            variant={variant}
-        >
-            <RequiredAsterisk required={required} />
-            {label}
-        </LabelText>
+        <RenderIf isTrue={label}>
+            <LabelText
+                className={className}
+                readOnly={readOnly}
+                labelAlignment={labelAlignment}
+                htmlFor={inputId}
+                as={as}
+                id={id}
+                variant={variant}
+            >
+                <RequiredAsterisk required={required} />
+                {label}
+            </LabelText>
+        </RenderIf>
     );
 }
 


### PR DESCRIPTION
## Changes proposed in this PR:
- Hide RequiredAsterisk when there is no label

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).