### PR TITLE
fix: update GMap script url

### DIFF
--- a/src/components/GMap/index.js
+++ b/src/components/GMap/index.js
@@ -12,9 +12,10 @@ export default function GMap(props) {
     const { apiKey, ...rest } = props;
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const Component = useCallback(scriptLoader(`${googleMapApiUrl}?key=${apiKey}`)(MapComponent), [
-        apiKey,
-    ]);
+    const Component = useCallback(
+        scriptLoader(`${googleMapApiUrl}?key=${apiKey}&libraries=places`)(MapComponent),
+        [apiKey],
+    );
     // eslint-disable-next-line react/jsx-props-no-spreading
     return <Component {...rest} />;
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Updated GMap API script url to match the one used in GoogleAddressLookup.

#### Detailed explanation:
The GoogleAddressLookup and GMap components both depends on the Maps API, loaded from a remote script using `react-async-script-loader`, but GoogleAddressLookup needs the places library (adding `&libraries=places` to the script url). This caused the URLs loaded by the components to differ, and the script to load twice.

The solution is to make the two components to load the same URL, this way `react-async-script-loader` realizes it is the same script and load only once. The downside to this approach is that when using the GMap component only, the Map API script loaded is a little bigger because it includes the places API even if it is not necessary.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
