### PR TITLE
fix: fix CheckboxGroup console error

### DIFF
--- a/src/components/CheckboxGroup/checkboxList.js
+++ b/src/components/CheckboxGroup/checkboxList.js
@@ -13,14 +13,13 @@ export default function CheckboxList(props) {
         const { description, ...rest } = option;
 
         return (
-            <StyledItemContainer data-id="input-checkboxgroup_container">
+            <StyledItemContainer key={key} data-id="input-checkboxgroup_container">
                 <Checkbox
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...rest}
                     checked={isOptionSelected(values, option)}
                     onChange={onChange}
                     ariaDescribedBy={describedBy}
-                    key={key}
                     name={name}
                     error={error}
                 />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2352 

## Changes proposed in this PR:
- Fixed error in console when using CheckboxGroup because `key  prop was on the wrong component. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
