### PR TITLE
feat: add new position resolvers

### DIFF
--- a/src/components/InternalOverlay/helpers/__test__/resolverTopLeft.spec.js
+++ b/src/components/InternalOverlay/helpers/__test__/resolverTopLeft.spec.js
@@ -1,0 +1,43 @@
+/* eslint-disable id-length */
+import resolverTopLeft from '../resolverTopLeft';
+
+describe('resolverTopLeft', () => {
+    it('should return the correct topLeft position', () => {
+        const param = {
+            trigger: {
+                leftUpAnchor: {
+                    x: 209,
+                    y: 150,
+                },
+                leftBottomAnchor: {
+                    x: 209,
+                    y: 215,
+                },
+                rightUpAnchor: {
+                    x: 249,
+                    y: 175,
+                },
+                rightBottomAnchor: {
+                    x: 249,
+                    y: 215,
+                },
+                width: 40,
+                height: 40,
+            },
+            viewport: {
+                width: 1100,
+                height: 400,
+            },
+            content: {
+                height: 380,
+                width: 120,
+            },
+        };
+        const expected = {
+            top: 0,
+            left: param.trigger.leftUpAnchor.x - param.content.width,
+        };
+
+        expect(resolverTopLeft(param)).toEqual(expected);
+    });
+});

--- a/src/components/InternalOverlay/helpers/__test__/resolverTopRight.spec.js
+++ b/src/components/InternalOverlay/helpers/__test__/resolverTopRight.spec.js
@@ -1,0 +1,43 @@
+/* eslint-disable id-length */
+import resolverTopRight from '../resolverTopRight';
+
+describe('resolverTopLeft', () => {
+    it('should return the correct topRight position', () => {
+        const param = {
+            trigger: {
+                leftUpAnchor: {
+                    x: 209,
+                    y: 150,
+                },
+                leftBottomAnchor: {
+                    x: 209,
+                    y: 215,
+                },
+                rightUpAnchor: {
+                    x: 249,
+                    y: 175,
+                },
+                rightBottomAnchor: {
+                    x: 249,
+                    y: 215,
+                },
+                width: 40,
+                height: 40,
+            },
+            viewport: {
+                width: 1100,
+                height: 400,
+            },
+            content: {
+                height: 380,
+                width: 120,
+            },
+        };
+        const expected = {
+            top: 0,
+            left: param.trigger.rightUpAnchor.x,
+        };
+
+        expect(resolverTopRight(param)).toEqual(expected);
+    });
+});

--- a/src/components/InternalOverlay/helpers/__test__/resolverTopRight.spec.js
+++ b/src/components/InternalOverlay/helpers/__test__/resolverTopRight.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable id-length */
 import resolverTopRight from '../resolverTopRight';
 
-describe('resolverTopLeft', () => {
+describe('resolverTopRight', () => {
     it('should return the correct topRight position', () => {
         const param = {
             trigger: {

--- a/src/components/InternalOverlay/helpers/defaultPositionResolver.js
+++ b/src/components/InternalOverlay/helpers/defaultPositionResolver.js
@@ -6,6 +6,8 @@ import resolverBottomCenter from './resolverBottomCenter';
 import resolverUpCenter from './resolverUpCenter';
 import resolverCenterLeft from './resolverCenterLeft';
 import resolverCenterRight from './resolverCenterRight';
+import resolverTopLeft from './resolverTopLeft';
+import resolverTopRight from './resolverTopRight';
 
 const DEFAULT_MARGIN = 5;
 
@@ -18,6 +20,8 @@ const resolvers = [
     resolverUpCenter,
     resolverCenterLeft,
     resolverCenterRight,
+    resolverTopLeft,
+    resolverTopRight,
 ];
 
 export default function defaultPositionResolver(opts) {

--- a/src/components/InternalOverlay/helpers/resolverTopLeft.js
+++ b/src/components/InternalOverlay/helpers/resolverTopLeft.js
@@ -1,0 +1,10 @@
+export default function resolverTopLeft(opts, margin = 0) {
+    const { trigger, content } = opts;
+    if (trigger.leftUpAnchor.x - margin - content.width >= 0) {
+        return {
+            top: 0,
+            left: trigger.leftUpAnchor.x - margin - content.width,
+        };
+    }
+    return false;
+}

--- a/src/components/InternalOverlay/helpers/resolverTopRight.js
+++ b/src/components/InternalOverlay/helpers/resolverTopRight.js
@@ -1,0 +1,10 @@
+export default function resolverTopRight(opts, margin = 0) {
+    const { trigger, content, viewport } = opts;
+    if (trigger.rightUpAnchor.x + margin + content.width <= viewport.width) {
+        return {
+            top: 0,
+            left: trigger.rightUpAnchor.x + margin,
+        };
+    }
+    return false;
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Added two new position resolvers to InternalOverlay:
  - Top left: positions the overlay at the left of the trigger with top: 0, applies when it is not possible to center the overlay on one of the sides.
  - Top right: same as above, but to the right of the trigger.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
