### PR TITLE
fix: add `children` prop to InternalOverlay types

### DIFF
--- a/src/components/InternalOverlay/index.d.ts
+++ b/src/components/InternalOverlay/index.d.ts
@@ -1,4 +1,4 @@
-import { RefObject, ComponentClass, FunctionComponent } from 'react';
+import { RefObject, ComponentClass, FunctionComponent, ReactNode } from 'react';
 
 type TriggerElementRefFunction = () => RefObject<HTMLElement>;
 
@@ -37,6 +37,7 @@ export interface InternalOverlayProps {
     positionResolver?: (opts: PositionResolverOpts) => Position;
     onOpened?: () => void;
     keepScrollEnabled?: boolean;
+    children?: ReactNode;
 }
 
 export default function(props: InternalOverlayProps): JSX.Element | null;


### PR DESCRIPTION
## Changes proposed in this PR:
- Added missing `children` prop to InternalOverlay types

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
