### PR TITLE
fix: update DatePickerModal value types

### DIFF
--- a/src/components/DatePickerModal/index.d.ts
+++ b/src/components/DatePickerModal/index.d.ts
@@ -1,11 +1,13 @@
 import { ReactNode } from 'react';
 import { BaseProps } from '../types';
 
+type Value = string | Date | Date[];
+
 export interface DatePickerModalProps extends BaseProps {
     id?: string;
     title?: ReactNode;
     isOpen?: boolean;
-    value?: string | Date;
+    value?: Value;
     maxDate?: Date;
     minDate?: Date;
     onChange?: (date: Date) => void;


### PR DESCRIPTION
## Changes proposed in this PR:
- Fixed DatePickerModal value types to include `Date[]`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
