### PR TITLE
fix: fix RadioGroup console error

### DIFF
--- a/src/components/RadioGroup/radioItems.js
+++ b/src/components/RadioGroup/radioItems.js
@@ -14,11 +14,10 @@ export default function RadioItems(props) {
         const key = `radio-${index}`;
         const { description, disabled, ...rest } = option;
         return (
-            <StyledItemContainer data-id="input-radiogroup_container">
+            <StyledItemContainer key={key} data-id="input-radiogroup_container">
                 <Radio
                     // eslint-disable-next-line react/jsx-props-no-spreading
                     {...rest}
-                    key={key}
                     onChange={onChange}
                     checked={isChecked(option)}
                     ariaDescribedby={ariaDescribedby}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2411

## Changes proposed in this PR:
- Fixed error in console when using RadioGroup because `key prop was on the wrong component.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
