### PR TITLE
feat: add `disabledDays` prop to Calendar

### DIFF
--- a/integration/specs/Calendar/calendar-11.spec.js
+++ b/integration/specs/Calendar/calendar-11.spec.js
@@ -1,0 +1,41 @@
+const PageCalendar = require('../../../src/components/Calendar/pageObject');
+
+const CALENDAR = '#calendar-11';
+
+describe('Calendar', () => {
+    beforeAll(async () => {
+        await browser.url('/#!/Calendar/11');
+    });
+    beforeEach(async () => {
+        await browser.refresh();
+        const component = await $(CALENDAR);
+        await component.waitForExist();
+    });
+    it('should set range initial date and end date button elements as selected', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickLeftMonthDay(2);
+        await calendar.clickRightMonthDay(16);
+        await expect(await calendar.isLeftMonthDaySelected(2)).toBe(true);
+        await expect(await calendar.isRightMonthDaySelected(16)).toBe(true);
+    });
+    it('should set range initial and end dates when using keyboard navigation', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickLeftMonthSelectYear();
+        await browser.keys('Escape');
+        await browser.keys('Tab');
+        await browser.keys('ArrowUp');
+        await browser.keys('ArrowLeft');
+        await browser.keys('Enter');
+        await browser.keys('PageDown');
+        await browser.keys('ArrowDown');
+        await browser.keys('Enter');
+        await expect(await calendar.isLeftMonthDaySelected(15)).toBe(true);
+        await expect(await calendar.isRightMonthDaySelected(22)).toBe(true);
+    });
+    it('should disable all days beyond the first disabled day when selecting range', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickRightMonthDay(14);
+        await expect(await calendar.isRightMonthDayEnabled(23)).toBe(false);
+        await expect(await calendar.isRightMonthDayEnabled(24)).toBe(false);
+    });
+});

--- a/integration/specs/Calendar/calendar-5.spec.js
+++ b/integration/specs/Calendar/calendar-5.spec.js
@@ -11,24 +11,9 @@ describe('Calendar', () => {
         const component = await $(CALENDAR);
         await component.waitForExist();
     });
-    it('should set range initial date and end date button elements as selected', async () => {
+    it('should disable the dates passed in `disabledDays`', async () => {
         const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickDay(2);
-        await calendar.clickDay(16);
-        await expect(await calendar.isDaySelected(2)).toBe(true);
-        await expect(await calendar.isDaySelected(16)).toBe(true);
-    });
-    it('should set range initial and end dates when using keyboard navigation', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickSelectYear();
-        await browser.keys('Escape');
-        await browser.keys('Tab');
-        await browser.keys('ArrowLeft');
-        await browser.keys('Enter');
-        await browser.keys('ArrowDown');
-        await browser.keys('ArrowDown');
-        await browser.keys('Enter');
-        await expect(await calendar.isDaySelected(2)).toBe(true);
-        await expect(await calendar.isDaySelected(16)).toBe(true);
+        await expect(await calendar.isDayEnabled(20)).toBe(false);
+        await expect(await calendar.isDayEnabled(21)).toBe(true);
     });
 });

--- a/integration/specs/Calendar/calendar-7.spec.js
+++ b/integration/specs/Calendar/calendar-7.spec.js
@@ -11,199 +11,24 @@ describe('Calendar', () => {
         const component = await $(CALENDAR);
         await component.waitForExist();
     });
-    it('should change months when clicked on left and right arrows', async () => {
+    it('should set range initial date and end date button elements as selected', async () => {
         const calendar = await PageCalendar(CALENDAR);
-        await expect(await calendar.getLeftSelectedMonth()).toBe('December');
-        await expect(await calendar.getRightSelectedMonth()).toBe('January');
-        await calendar.clickPrevMonthButton();
-        await expect(await calendar.getLeftSelectedMonth()).toBe('November');
-        await expect(await calendar.getRightSelectedMonth()).toBe('December');
-        await calendar.clickNextMonthButton();
-        await calendar.clickNextMonthButton();
-        await expect(await calendar.getLeftSelectedMonth()).toBe('January');
-        await expect(await calendar.getRightSelectedMonth()).toBe('February');
+        await calendar.clickDay(2);
+        await calendar.clickDay(16);
+        await expect(await calendar.isDaySelected(2)).toBe(true);
+        await expect(await calendar.isDaySelected(16)).toBe(true);
     });
-    it('should select the right day button element', async () => {
+    it('should set range initial and end dates when using keyboard navigation', async () => {
         const calendar = await PageCalendar(CALENDAR);
-        await expect(await calendar.getLeftMonthSelectedDay()).toBe('11');
-        await expect(await calendar.getRightMonthSelectedDay()).toBe(undefined);
-        await calendar.clickLeftMonthDay(5);
-        await expect(await calendar.getLeftMonthSelectedDay()).toBe('5');
-        await expect(await calendar.getRightMonthSelectedDay()).toBe(undefined);
-        await calendar.clickRightMonthDay(6);
-        await expect(await calendar.getLeftMonthSelectedDay()).toBe(undefined);
-        await expect(await calendar.getRightMonthSelectedDay()).toBe('6');
-    });
-    it('should focus the correct day in left month when an arrow key is pressed', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickLeftMonthDay(11);
-        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
-        await browser.keys('ArrowUp');
-        await expect(await calendar.isLeftMonthDayFocused(4)).toBe(true);
-        await browser.keys('ArrowDown');
-        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
-        await browser.keys('ArrowLeft');
-        await expect(await calendar.isLeftMonthDayFocused(10)).toBe(true);
-        await browser.keys('ArrowRight');
-        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
-    });
-    it('should focus the correct day in right month when an arrow key is pressed', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickRightMonthDay(11);
-        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
-        await browser.keys('ArrowUp');
-        await expect(await calendar.isRightMonthDayFocused(4)).toBe(true);
-        await browser.keys('ArrowDown');
-        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
-        await browser.keys('ArrowLeft');
-        await expect(await calendar.isRightMonthDayFocused(10)).toBe(true);
-        await browser.keys('ArrowRight');
-        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
-    });
-    it('should focus the first day of the week in left month when HOME key is pressed', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickLeftMonthDay(11);
-        await browser.keys('Home');
-        await expect(await calendar.isLeftMonthDayFocused(8)).toBe(true);
-    });
-    it('should focus the first day of the week in right month when HOME key is pressed', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickRightMonthDay(11);
-        await browser.keys('Home');
-        await expect(await calendar.isRightMonthDayFocused(5)).toBe(true);
-    });
-    it('should focus the last day of the week in left month when END key is pressed', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickLeftMonthDay(11);
-        await browser.keys('End');
-        await expect(await calendar.isLeftMonthDayFocused(14)).toBe(true);
-    });
-    it('should focus the last day of the week in right month when END key is pressed', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickRightMonthDay(8);
-        await browser.keys('End');
-        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
-    });
-    it('should change to the previous month when is in the first day of a month and press LEFT OR UP arrow keys', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickLeftMonthDay(1);
-        await browser.keys('ArrowLeft');
-        await expect(await calendar.getLeftSelectedMonth()).toBe('November');
-        await expect(await calendar.isLeftMonthDayFocused(30)).toBe(true);
-        await calendar.clickRightMonthDay(1);
-        await expect(await calendar.isLeftMonthDayFocused(30)).toBe(true);
-    });
-    it('should change to next month when is in the last day of a month and press RIGHT OR DOWN arrow keys', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickLeftMonthDay(31);
-        await browser.keys('ArrowRight');
-        await expect(await calendar.isRightMonthDayFocused(1)).toBe(true);
-        await calendar.clickRightMonthDay(31);
-        await browser.keys('ArrowRight');
-        await expect(await calendar.getLeftSelectedMonth()).toBe('January');
-        await expect(await calendar.getRightSelectedMonth()).toBe('February');
-        await expect(await calendar.isRightMonthDayFocused(1)).toBe(true);
-    });
-    it('should change to the previous month when PAGEUP key is pressed', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickRightMonthDay(11);
-        await browser.keys('PageUp');
-        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
-        await browser.keys('PageUp');
-        await expect(await calendar.getLeftSelectedMonth()).toBe('November');
-        await expect(await calendar.getRightSelectedMonth()).toBe('December');
-        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
-    });
-    it('should change to next month when PAGEDOWN key is pressed', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickLeftMonthDay(11);
-        await browser.keys('PageDown');
-        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
-        await browser.keys('PageDown');
-        await expect(await calendar.getLeftSelectedMonth()).toBe('January');
-        await expect(await calendar.getRightSelectedMonth()).toBe('February');
-        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
-    });
-    it('should change to the previous year when ALT + PAGEUP keys are pressed', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickLeftMonthDay(11);
-        await browser.keys(['Alt', 'PageUp']);
-        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
-        await expect(await calendar.getLeftSelectedMonth()).toBe('December');
-        await expect(await calendar.getLeftMonthSelectedYear()).toBe('2018');
-        await expect(await calendar.getRightSelectedMonth()).toBe('January');
-        await expect(await calendar.getRightMonthSelectedYear()).toBe('2019');
-    });
-    it('should select a day when press ENTER key while is focused', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickLeftMonthDay(11);
-        await browser.keys('ArrowLeft');
-        await browser.keys('Enter');
-        await expect(await calendar.isLeftMonthDaySelected(10)).toBe(true);
-        await calendar.clickRightMonthDay(11);
-        await browser.keys('ArrowLeft');
-        await browser.keys('Enter');
-        await expect(await calendar.isRightMonthDaySelected(10)).toBe(true);
-    });
-    it('should focus the selected day when tab reach days table', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickLeftMonthSelectYear();
-        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(false);
+        await calendar.clickSelectYear();
         await browser.keys('Escape');
         await browser.keys('Tab');
-        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
-        await calendar.clickRightMonthDay(11);
-        await calendar.clickRightMonthSelectYear();
-        await expect(await calendar.isRightMonthDayFocused(11)).toBe(false);
-        await browser.keys('Escape');
-        await browser.keys('Tab');
-        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
-    });
-    it('should change to next year when ALT + PAGEDOWN keys are pressed', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickLeftMonthDay(10);
-        await browser.keys(['Alt', 'PageDown']);
-        await expect(await calendar.isLeftMonthDayFocused(10)).toBe(true);
-        await expect(await calendar.getLeftSelectedMonth()).toBe('December');
-        await expect(await calendar.getLeftMonthSelectedYear()).toBe('2020');
-        await expect(await calendar.getRightSelectedMonth()).toBe('January');
-        await expect(await calendar.getRightMonthSelectedYear()).toBe('2021');
-    });
-    it('should navigate on the header when using arrow keys', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickPrevMonthButton();
-        await expect(await calendar.isPrevMonthButtonFocused()).toBe(true);
-        await expect(await calendar.isLeftYearSelectFocused()).toBe(false);
-        await expect(await calendar.isRightYearSelectFocused()).toBe(false);
-        await expect(await calendar.isNextMonthButtonFocused()).toBe(false);
         await browser.keys('ArrowLeft');
-        await expect(await calendar.isPrevMonthButtonFocused()).toBe(true);
-        await expect(await calendar.isLeftYearSelectFocused()).toBe(false);
-        await expect(await calendar.isRightYearSelectFocused()).toBe(false);
-        await expect(await calendar.isNextMonthButtonFocused()).toBe(false);
-        await browser.keys('ArrowRight');
-        await expect(await calendar.isPrevMonthButtonFocused()).toBe(false);
-        await expect(await calendar.isLeftYearSelectFocused()).toBe(true);
-        await expect(await calendar.isRightYearSelectFocused()).toBe(false);
-        await expect(await calendar.isNextMonthButtonFocused()).toBe(false);
-        await browser.keys('ArrowRight');
-        await expect(await calendar.isPrevMonthButtonFocused()).toBe(false);
-        await expect(await calendar.isLeftYearSelectFocused()).toBe(false);
-        await expect(await calendar.isRightYearSelectFocused()).toBe(true);
-        await expect(await calendar.isNextMonthButtonFocused()).toBe(false);
-        await browser.keys('ArrowRight');
-        await expect(await calendar.isPrevMonthButtonFocused()).toBe(false);
-        await expect(await calendar.isLeftYearSelectFocused()).toBe(false);
-        await expect(await calendar.isRightYearSelectFocused()).toBe(false);
-        await expect(await calendar.isNextMonthButtonFocused()).toBe(true);
-    });
-    it('should move from calendar controls to days when TAB key is pressed', async () => {
-        const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickPrevMonthButton();
-        await expect(await calendar.isLeftMonthDayFocused(1)).toBe(false);
-        await browser.keys('Tab');
-        await expect(await calendar.isLeftMonthDayFocused(1)).toBe(true);
-        await browser.keys('Tab');
-        await expect(await calendar.isLeftMonthDayFocused(1)).toBe(false);
+        await browser.keys('Enter');
+        await browser.keys('ArrowDown');
+        await browser.keys('ArrowDown');
+        await browser.keys('Enter');
+        await expect(await calendar.isDaySelected(2)).toBe(true);
+        await expect(await calendar.isDaySelected(16)).toBe(true);
     });
 });

--- a/integration/specs/Calendar/calendar-9.spec.js
+++ b/integration/specs/Calendar/calendar-9.spec.js
@@ -11,24 +11,199 @@ describe('Calendar', () => {
         const component = await $(CALENDAR);
         await component.waitForExist();
     });
-    it('should set range initial date and end date button elements as selected', async () => {
+    it('should change months when clicked on left and right arrows', async () => {
         const calendar = await PageCalendar(CALENDAR);
-        await calendar.clickLeftMonthDay(2);
-        await calendar.clickRightMonthDay(16);
-        await expect(await calendar.isLeftMonthDaySelected(2)).toBe(true);
-        await expect(await calendar.isRightMonthDaySelected(16)).toBe(true);
+        await expect(await calendar.getLeftSelectedMonth()).toBe('December');
+        await expect(await calendar.getRightSelectedMonth()).toBe('January');
+        await calendar.clickPrevMonthButton();
+        await expect(await calendar.getLeftSelectedMonth()).toBe('November');
+        await expect(await calendar.getRightSelectedMonth()).toBe('December');
+        await calendar.clickNextMonthButton();
+        await calendar.clickNextMonthButton();
+        await expect(await calendar.getLeftSelectedMonth()).toBe('January');
+        await expect(await calendar.getRightSelectedMonth()).toBe('February');
     });
-    it('should set range initial and end dates when using keyboard navigation', async () => {
+    it('should select the right day button element', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await expect(await calendar.getLeftMonthSelectedDay()).toBe('11');
+        await expect(await calendar.getRightMonthSelectedDay()).toBe(undefined);
+        await calendar.clickLeftMonthDay(5);
+        await expect(await calendar.getLeftMonthSelectedDay()).toBe('5');
+        await expect(await calendar.getRightMonthSelectedDay()).toBe(undefined);
+        await calendar.clickRightMonthDay(6);
+        await expect(await calendar.getLeftMonthSelectedDay()).toBe(undefined);
+        await expect(await calendar.getRightMonthSelectedDay()).toBe('6');
+    });
+    it('should focus the correct day in left month when an arrow key is pressed', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickLeftMonthDay(11);
+        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
+        await browser.keys('ArrowUp');
+        await expect(await calendar.isLeftMonthDayFocused(4)).toBe(true);
+        await browser.keys('ArrowDown');
+        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
+        await browser.keys('ArrowLeft');
+        await expect(await calendar.isLeftMonthDayFocused(10)).toBe(true);
+        await browser.keys('ArrowRight');
+        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
+    });
+    it('should focus the correct day in right month when an arrow key is pressed', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickRightMonthDay(11);
+        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
+        await browser.keys('ArrowUp');
+        await expect(await calendar.isRightMonthDayFocused(4)).toBe(true);
+        await browser.keys('ArrowDown');
+        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
+        await browser.keys('ArrowLeft');
+        await expect(await calendar.isRightMonthDayFocused(10)).toBe(true);
+        await browser.keys('ArrowRight');
+        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
+    });
+    it('should focus the first day of the week in left month when HOME key is pressed', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickLeftMonthDay(11);
+        await browser.keys('Home');
+        await expect(await calendar.isLeftMonthDayFocused(8)).toBe(true);
+    });
+    it('should focus the first day of the week in right month when HOME key is pressed', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickRightMonthDay(11);
+        await browser.keys('Home');
+        await expect(await calendar.isRightMonthDayFocused(5)).toBe(true);
+    });
+    it('should focus the last day of the week in left month when END key is pressed', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickLeftMonthDay(11);
+        await browser.keys('End');
+        await expect(await calendar.isLeftMonthDayFocused(14)).toBe(true);
+    });
+    it('should focus the last day of the week in right month when END key is pressed', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickRightMonthDay(8);
+        await browser.keys('End');
+        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
+    });
+    it('should change to the previous month when is in the first day of a month and press LEFT OR UP arrow keys', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickLeftMonthDay(1);
+        await browser.keys('ArrowLeft');
+        await expect(await calendar.getLeftSelectedMonth()).toBe('November');
+        await expect(await calendar.isLeftMonthDayFocused(30)).toBe(true);
+        await calendar.clickRightMonthDay(1);
+        await expect(await calendar.isLeftMonthDayFocused(30)).toBe(true);
+    });
+    it('should change to next month when is in the last day of a month and press RIGHT OR DOWN arrow keys', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickLeftMonthDay(31);
+        await browser.keys('ArrowRight');
+        await expect(await calendar.isRightMonthDayFocused(1)).toBe(true);
+        await calendar.clickRightMonthDay(31);
+        await browser.keys('ArrowRight');
+        await expect(await calendar.getLeftSelectedMonth()).toBe('January');
+        await expect(await calendar.getRightSelectedMonth()).toBe('February');
+        await expect(await calendar.isRightMonthDayFocused(1)).toBe(true);
+    });
+    it('should change to the previous month when PAGEUP key is pressed', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickRightMonthDay(11);
+        await browser.keys('PageUp');
+        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
+        await browser.keys('PageUp');
+        await expect(await calendar.getLeftSelectedMonth()).toBe('November');
+        await expect(await calendar.getRightSelectedMonth()).toBe('December');
+        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
+    });
+    it('should change to next month when PAGEDOWN key is pressed', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickLeftMonthDay(11);
+        await browser.keys('PageDown');
+        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
+        await browser.keys('PageDown');
+        await expect(await calendar.getLeftSelectedMonth()).toBe('January');
+        await expect(await calendar.getRightSelectedMonth()).toBe('February');
+        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
+    });
+    it('should change to the previous year when ALT + PAGEUP keys are pressed', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickLeftMonthDay(11);
+        await browser.keys(['Alt', 'PageUp']);
+        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
+        await expect(await calendar.getLeftSelectedMonth()).toBe('December');
+        await expect(await calendar.getLeftMonthSelectedYear()).toBe('2018');
+        await expect(await calendar.getRightSelectedMonth()).toBe('January');
+        await expect(await calendar.getRightMonthSelectedYear()).toBe('2019');
+    });
+    it('should select a day when press ENTER key while is focused', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickLeftMonthDay(11);
+        await browser.keys('ArrowLeft');
+        await browser.keys('Enter');
+        await expect(await calendar.isLeftMonthDaySelected(10)).toBe(true);
+        await calendar.clickRightMonthDay(11);
+        await browser.keys('ArrowLeft');
+        await browser.keys('Enter');
+        await expect(await calendar.isRightMonthDaySelected(10)).toBe(true);
+    });
+    it('should focus the selected day when tab reach days table', async () => {
         const calendar = await PageCalendar(CALENDAR);
         await calendar.clickLeftMonthSelectYear();
+        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(false);
         await browser.keys('Escape');
         await browser.keys('Tab');
-        await browser.keys('ArrowUp');
-        await browser.keys('Enter');
-        await browser.keys('PageDown');
-        await browser.keys('ArrowDown');
-        await browser.keys('Enter');
-        await expect(await calendar.isLeftMonthDaySelected(16)).toBe(true);
-        await expect(await calendar.isRightMonthDaySelected(23)).toBe(true);
+        await expect(await calendar.isLeftMonthDayFocused(11)).toBe(true);
+        await calendar.clickRightMonthDay(11);
+        await calendar.clickRightMonthSelectYear();
+        await expect(await calendar.isRightMonthDayFocused(11)).toBe(false);
+        await browser.keys('Escape');
+        await browser.keys('Tab');
+        await expect(await calendar.isRightMonthDayFocused(11)).toBe(true);
+    });
+    it('should change to next year when ALT + PAGEDOWN keys are pressed', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickLeftMonthDay(10);
+        await browser.keys(['Alt', 'PageDown']);
+        await expect(await calendar.isLeftMonthDayFocused(10)).toBe(true);
+        await expect(await calendar.getLeftSelectedMonth()).toBe('December');
+        await expect(await calendar.getLeftMonthSelectedYear()).toBe('2020');
+        await expect(await calendar.getRightSelectedMonth()).toBe('January');
+        await expect(await calendar.getRightMonthSelectedYear()).toBe('2021');
+    });
+    it('should navigate on the header when using arrow keys', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickPrevMonthButton();
+        await expect(await calendar.isPrevMonthButtonFocused()).toBe(true);
+        await expect(await calendar.isLeftYearSelectFocused()).toBe(false);
+        await expect(await calendar.isRightYearSelectFocused()).toBe(false);
+        await expect(await calendar.isNextMonthButtonFocused()).toBe(false);
+        await browser.keys('ArrowLeft');
+        await expect(await calendar.isPrevMonthButtonFocused()).toBe(true);
+        await expect(await calendar.isLeftYearSelectFocused()).toBe(false);
+        await expect(await calendar.isRightYearSelectFocused()).toBe(false);
+        await expect(await calendar.isNextMonthButtonFocused()).toBe(false);
+        await browser.keys('ArrowRight');
+        await expect(await calendar.isPrevMonthButtonFocused()).toBe(false);
+        await expect(await calendar.isLeftYearSelectFocused()).toBe(true);
+        await expect(await calendar.isRightYearSelectFocused()).toBe(false);
+        await expect(await calendar.isNextMonthButtonFocused()).toBe(false);
+        await browser.keys('ArrowRight');
+        await expect(await calendar.isPrevMonthButtonFocused()).toBe(false);
+        await expect(await calendar.isLeftYearSelectFocused()).toBe(false);
+        await expect(await calendar.isRightYearSelectFocused()).toBe(true);
+        await expect(await calendar.isNextMonthButtonFocused()).toBe(false);
+        await browser.keys('ArrowRight');
+        await expect(await calendar.isPrevMonthButtonFocused()).toBe(false);
+        await expect(await calendar.isLeftYearSelectFocused()).toBe(false);
+        await expect(await calendar.isRightYearSelectFocused()).toBe(false);
+        await expect(await calendar.isNextMonthButtonFocused()).toBe(true);
+    });
+    it('should move from calendar controls to days when TAB key is pressed', async () => {
+        const calendar = await PageCalendar(CALENDAR);
+        await calendar.clickPrevMonthButton();
+        await expect(await calendar.isLeftMonthDayFocused(1)).toBe(false);
+        await browser.keys('Tab');
+        await expect(await calendar.isLeftMonthDayFocused(1)).toBe(true);
+        await browser.keys('Tab');
+        await expect(await calendar.isLeftMonthDayFocused(1)).toBe(false);
     });
 });

--- a/src/components/Calendar/day.js
+++ b/src/components/Calendar/day.js
@@ -8,6 +8,7 @@ import StyledDayButton from './styled/dayButton';
 import StyledRangeHighlight from './styled/rangeHighlight';
 import { isSameDay, compareDates } from './helpers';
 import { useRangeStartDate, useRangeEndDate } from './hooks';
+import isInArray from './helpers/isInArray';
 
 function DayComponent(props) {
     const {
@@ -16,6 +17,7 @@ function DayComponent(props) {
         isSelected,
         minDate,
         maxDate,
+        maxRangeEnd,
         onChange,
         isWithinRange,
         isFirstDayOfWeek,
@@ -23,14 +25,20 @@ function DayComponent(props) {
         useAutoFocus,
         focusedDate,
         currentRange,
+        disabledDays,
         privateKeyDown,
         privateOnFocus,
         privateOnBlur,
         privateOnHover,
     } = props;
+
     const day = date.getDate();
     const isAdjacentDate = date.getMonth() !== firstDayMonth.getMonth();
-    const isDisabled = compareDates(date, maxDate) > 0 || compareDates(date, minDate) < 0;
+    const isDisabled =
+        compareDates(date, maxDate) > 0 ||
+        compareDates(date, minDate) < 0 ||
+        (maxRangeEnd && compareDates(date, maxRangeEnd) > 0) ||
+        isInArray(date, disabledDays);
     const tabIndex = isSameDay(focusedDate, date) ? 0 : -1;
     const buttonRef = useRef();
     const isRangeStartDate = useRangeStartDate(date, currentRange);

--- a/src/components/Calendar/helpers/__test__/isInArray.spec.js
+++ b/src/components/Calendar/helpers/__test__/isInArray.spec.js
@@ -1,0 +1,14 @@
+import isInArray from '../isInArray';
+
+describe('isInArray', () => {
+    it('should return true', () => {
+        const array = ['09/07/2022', new Date('09/08/2022')];
+        expect(isInArray(new Date('09/07/2022'), array)).toBe(true);
+        expect(isInArray('09/08/2022', array)).toBe(true);
+    });
+    it('should return false', () => {
+        const array = ['09/07/2022', new Date('09/08/2022')];
+        expect(isInArray(new Date('10/07/2022'), array)).toBe(false);
+        expect(isInArray('09/08/2022', undefined)).toBe(false);
+    });
+});

--- a/src/components/Calendar/helpers/__test__/normalizeDates.spec.js
+++ b/src/components/Calendar/helpers/__test__/normalizeDates.spec.js
@@ -1,0 +1,9 @@
+import normalizeDates from '../normalizeDates';
+
+describe('normalizeDates', () => {
+    it('should return normalize the array of dates', () => {
+        const array = [undefined, '09/07/2022', new Date('09/08/2022'), 1];
+        const expected = [new Date('09/07/2022'), new Date('09/08/2022')];
+        expect(normalizeDates(array)).toEqual(expected);
+    });
+});

--- a/src/components/Calendar/helpers/index.js
+++ b/src/components/Calendar/helpers/index.js
@@ -22,3 +22,4 @@ export { default as buildNewRangeFromValue } from './buildNewRangeFromValue';
 export { default as shouldDateBeSelected } from './shouldDateBeSelected';
 export { default as isSameDatesRange } from './isSameDatesRange';
 export { default as isEmptyRange } from './isEmptyRange';
+export { default as normalizeDates } from './normalizeDates';

--- a/src/components/Calendar/helpers/isInArray.js
+++ b/src/components/Calendar/helpers/isInArray.js
@@ -1,0 +1,6 @@
+import isSameDay from './isSameDay';
+
+export default function isInArray(value, array) {
+    if (!array) return false;
+    return array.some(day => isSameDay(day, value));
+}

--- a/src/components/Calendar/helpers/normalizeDate.js
+++ b/src/components/Calendar/helpers/normalizeDate.js
@@ -1,3 +1,6 @@
 export default function normalizeDate(date) {
+    if (typeof date === 'string') {
+        return new Date(date);
+    }
     return date || new Date();
 }

--- a/src/components/Calendar/helpers/normalizeDates.js
+++ b/src/components/Calendar/helpers/normalizeDates.js
@@ -1,0 +1,7 @@
+import normalizeDate from './normalizeDate';
+
+export default function normalizeDates(dates) {
+    return dates
+        .filter(date => date && (typeof date === 'string' || date instanceof Date))
+        .map(date => normalizeDate(date));
+}

--- a/src/components/Calendar/index.d.ts
+++ b/src/components/Calendar/index.d.ts
@@ -10,6 +10,7 @@ export interface CalendarProps extends BaseProps {
     selectionType?: 'single' | 'range';
     variant?: 'single' | 'double';
     locale?: string;
+    disabledDays?: Array<string | Date>;
 }
 
 declare const Calendar: ComponentType<CalendarProps>;

--- a/src/components/Calendar/index.js
+++ b/src/components/Calendar/index.js
@@ -78,6 +78,10 @@ Calendar.propTypes = {
     selectionType: PropTypes.oneOf(['single', 'range']),
     /** The component variant. Defaults to 'single' */
     variant: PropTypes.oneOf(['single', 'double']),
+    /** An array containing the days that should be disabled */
+    disabledDays: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
+    ),
 };
 
 Calendar.defaultProps = {
@@ -91,4 +95,5 @@ Calendar.defaultProps = {
     locale: undefined,
     selectionType: 'single',
     variant: 'single',
+    disabledDays: [],
 };

--- a/src/components/Calendar/pageObject/doubleCalendar.js
+++ b/src/components/Calendar/pageObject/doubleCalendar.js
@@ -172,6 +172,18 @@ class PageDoubleCalendar {
     }
 
     /**
+     * Returns true when the specific day element in left month is selected.
+     * @method
+     * @returns {string}
+     */
+    async isLeftMonthDayEnabled(day) {
+        const buttonEl = await $(this.rootElement)
+            .$$('table[role=grid]')[0]
+            .$(`button=${day}`);
+        return buttonEl.isExisting();
+    }
+
+    /**
      * Returns true when the year select element in left month has focus.
      * @method
      * @returns {bool}
@@ -276,6 +288,18 @@ class PageDoubleCalendar {
             (await buttonEl.isExisting()) &&
             (await buttonEl.getAttribute('data-selected')) === 'true'
         );
+    }
+
+    /**
+     * Returns true when the specific day element in right month is selected.
+     * @method
+     * @returns {string}
+     */
+    async isRightMonthDayEnabled(day) {
+        const buttonEl = await $(this.rootElement)
+            .$$('table[role=grid]')[1]
+            .$(`button=${day}`);
+        return buttonEl.isExisting();
     }
 
     /**

--- a/src/components/Calendar/pageObject/singleCalendar.js
+++ b/src/components/Calendar/pageObject/singleCalendar.js
@@ -103,6 +103,18 @@ class PageSingleCalendar {
     }
 
     /**
+     * Returns true when the specific day element is selected.
+     * @method
+     * @returns {string}
+     */
+    async isDayEnabled(day) {
+        const spanEl = await $(this.rootElement)
+            .$('table')
+            .$(`button=${day}`);
+        return spanEl.isExisting();
+    }
+
+    /**
      * Set the value of the year select element
      * @method
      * @param {string}

--- a/src/components/Calendar/readme.md
+++ b/src/components/Calendar/readme.md
@@ -1,4 +1,5 @@
-##### Calendar base:
+# Base Calendar
+##### To pick a single date you can use a basic calendar.
 
 ```js
 import React from 'react';
@@ -43,7 +44,8 @@ const selectStyles = {
     </div>
 ```
 
-##### Calendar with dates contrains:
+# Calendar with dates contrains
+##### If you need to limit the available dates you can do so with `minDate` and `maxDate` props
 
 ```js
 import React from 'react';
@@ -70,7 +72,35 @@ const calendarContainerStyles = {
     </div>
 ```
 
-##### Calendar with range selection:
+# Calendar with disabled days
+##### If more control over the available dates is needed, the `disabledDays` prop provides a way to disable individual days
+
+```js
+import React from 'react';
+import { Card, Calendar } from 'react-rainbow-components';
+
+const initialState = { date: new Date('2019-11-11 00:00:00') };
+const calendarContainerStyles = {
+    width: '28rem',
+    height: '27rem',
+};
+
+    <div>
+        <div className="rainbow-align-content_center rainbow-p-vertical_xx-large rainbow-p-horizontal_medium">
+            <Card style={calendarContainerStyles} className="rainbow-p-around_large">
+                <Calendar
+                    id="calendar-5"
+                    value={state.date}
+                    onChange={value => setState({ date: value })}
+                    disabledDays={['2019/11/15', new Date('2019/11/20')]}
+                />
+            </Card>
+        </div>
+    </div>
+```
+
+# Calendar with range selection
+##### Use `selectionType = 'range'` to allow your users to pick a range of dates
 
 ```js
 import React from 'react';
@@ -89,17 +119,19 @@ const calendarContainerStyles = {
         <div className="rainbow-align-content_center rainbow-p-vertical_xx-large rainbow-p-horizontal_medium">
             <Card style={calendarContainerStyles} className="rainbow-p-around_large">
                 <Calendar
-                    id="calendar-5"
+                    id="calendar-7"
                     selectionType="range"
                     value={state.range}
                     onChange={value => setState({ range: value })}
+                    disabledDays={['2019/01/23']}
                 />
             </Card>
         </div>
     </div>
 ```
 
-##### Calendar with variant double:
+# Calendar with variant double
+##### Set the `variant` prop to 'double' if you want to show two months side by side
 
 ```js
 import React from 'react';
@@ -115,7 +147,7 @@ const calendarContainerStyles = {
             style={calendarContainerStyles}
         >
             <Calendar
-                id="calendar-7"
+                id="calendar-9"
                 variant="double"
                 value={state.date}
                 onChange={value => setState({ date: value })}
@@ -124,7 +156,8 @@ const calendarContainerStyles = {
     </div>
 ```
 
-##### Calendar with variant double and range selection:
+# Calendar with variant double and range selection
+##### The best use case for double variant is to ease the selection of large date ranges
 
 ```js
 import React from 'react';
@@ -145,11 +178,12 @@ const calendarContainerStyles = {
             style={calendarContainerStyles}
         >
             <Calendar
-                id="calendar-9"
+                id="calendar-11"
                 variant="double"
                 selectionType="range"
                 value={state.range}
                 onChange={value => setState({ range: value })}
+                disabledDays={['2020/01/23']}
             />
         </div>
     </div>

--- a/src/components/DatePicker/index.d.ts
+++ b/src/components/DatePicker/index.d.ts
@@ -29,6 +29,7 @@ export interface DatePickerProps extends BaseProps {
     selectionType?: 'single' | 'range';
     variant?: 'single' | 'double';
     icon?: ReactNode;
+    disabledDays?: Array<Date | string>;
 }
 
 export default function(props: DatePickerProps): JSX.Element | null;

--- a/src/components/DatePicker/index.js
+++ b/src/components/DatePicker/index.js
@@ -42,6 +42,7 @@ const DatePicker = React.forwardRef((props, ref) => {
         variant,
         selectionType,
         icon: iconInProps,
+        disabledDays,
     } = useReduxForm(props);
 
     const currentLocale = useLocale(locale);
@@ -141,6 +142,7 @@ const DatePicker = React.forwardRef((props, ref) => {
                 value={value}
                 onChange={handleChange}
                 onRequestClose={closeModal}
+                disabledDays={disabledDays}
             />
         </StyledContainer>
     );
@@ -211,6 +213,10 @@ DatePicker.propTypes = {
     variant: PropTypes.oneOf(['single', 'double']),
     /** The icon to show if it is passed. It must be a svg icon or a font icon. Defaults to a Calendar icon */
     icon: PropTypes.node,
+    /** An array containing the days that should be disabled */
+    disabledDays: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
+    ),
 };
 
 DatePicker.defaultProps = {
@@ -241,6 +247,7 @@ DatePicker.defaultProps = {
     selectionType: 'single',
     variant: 'single',
     icon: undefined,
+    disabledDays: [],
 };
 
 export default DatePicker;

--- a/src/components/DatePickerModal/index.d.ts
+++ b/src/components/DatePickerModal/index.d.ts
@@ -15,6 +15,7 @@ export interface DatePickerModalProps extends BaseProps {
     selectionType?: 'single' | 'range';
     variant?: 'single' | 'double';
     locale?: string;
+    disabledDays?: Array<Date | string>;
 }
 
 export default function(props: DatePickerModalProps): JSX.Element | null;

--- a/src/components/DatePickerModal/index.js
+++ b/src/components/DatePickerModal/index.js
@@ -18,6 +18,7 @@ export default function DatePickerModal(props) {
         onRequestClose,
         isOpen,
         title,
+        disabledDays,
     } = props;
 
     const calendarId = id && `${id}_calendar`;
@@ -44,6 +45,7 @@ export default function DatePickerModal(props) {
                 variant={variant}
                 value={value}
                 onChange={onChange}
+                disabledDays={disabledDays}
             />
         </StyledModal>
     );
@@ -86,6 +88,10 @@ DatePickerModal.propTypes = {
     /** The title can include text or another component,
      * and is displayed in the header of the component. */
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+    /** An array containing the days that should be disabled */
+    disabledDays: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
+    ),
 };
 
 DatePickerModal.defaultProps = {
@@ -102,4 +108,5 @@ DatePickerModal.defaultProps = {
     onChange: () => {},
     onRequestClose: () => {},
     title: undefined,
+    disabledDays: [],
 };

--- a/src/components/DateTimePicker/index.d.ts
+++ b/src/components/DateTimePicker/index.d.ts
@@ -8,6 +8,7 @@ export interface DateTimePickerProps extends DatePickerProps {
     hour24?: boolean;
     labelAlignment?: LabelAlignment;
     hideLabel?: boolean;
+    disabledDays?: Array<Date | string>;
 }
 
 declare const DatePicker: ComponentType<DateTimePickerProps>;

--- a/src/components/DateTimePicker/index.js
+++ b/src/components/DateTimePicker/index.js
@@ -45,6 +45,7 @@ const DateTimePicker = React.forwardRef((props, ref) => {
         hour24,
         locale: localeProp,
         icon: iconInProps,
+        disabledDays,
     } = props;
 
     const inputRef = useRef();
@@ -145,6 +146,7 @@ const DateTimePicker = React.forwardRef((props, ref) => {
                 cancelLabel={cancelLabel}
                 locale={locale}
                 hour24={hour24}
+                disabledDays={disabledDays}
             />
         </StyledContainer>
     );
@@ -214,6 +216,10 @@ DateTimePicker.propTypes = {
     hour24: PropTypes.bool,
     /** The icon to show if it is passed. It must be a svg icon or a font icon. Defaults to a DateTime icon */
     icon: PropTypes.node,
+    /** An array containing the days that should be disabled */
+    disabledDays: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
+    ),
 };
 
 DateTimePicker.defaultProps = {
@@ -245,6 +251,7 @@ DateTimePicker.defaultProps = {
     locale: undefined,
     hour24: false,
     icon: undefined,
+    disabledDays: [],
 };
 
 export default withReduxForm(DateTimePicker);

--- a/src/components/DateTimePicker/pickerModal.js
+++ b/src/components/DateTimePicker/pickerModal.js
@@ -26,6 +26,7 @@ function DateTimePickerModal(props) {
         onChange,
         locale,
         hour24,
+        disabledDays,
     } = props;
 
     const [date, setDate] = useState(value);
@@ -67,6 +68,7 @@ function DateTimePickerModal(props) {
                     maxDate={maxDate}
                     formatStyle={formatStyle}
                     onChange={handleDateChange}
+                    disabledDays={disabledDays}
                 />
                 <StyledDivider />
                 <StyledTimeSelect
@@ -96,6 +98,9 @@ DateTimePickerModal.propTypes = {
     onChange: PropTypes.func,
     locale: PropTypes.string,
     hour24: PropTypes.bool,
+    disabledDays: PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
+    ),
 };
 
 DateTimePickerModal.defaultProps = {
@@ -109,6 +114,7 @@ DateTimePickerModal.defaultProps = {
     onChange: () => {},
     locale: undefined,
     hour24: false,
+    disabledDays: [],
 };
 
 export default DateTimePickerModal;


### PR DESCRIPTION
fix: #2423 

## Changes proposed in this PR:
- Added `disabledDays` prop to Calendar, DatePicker, DateTimePicker and its modals

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
