### PR TITLE
fix: types in onSort prop of the table to be more strict

### DIFF
--- a/src/components/Table/index.d.ts
+++ b/src/components/Table/index.d.ts
@@ -6,7 +6,11 @@ export interface TableProps extends BaseProps {
     sortedBy?: string;
     sortDirection?: 'asc' | 'desc';
     defaultSortDirection?: 'asc' | 'desc';
-    onSort?: (event: MouseEvent<HTMLElement>, field: string, nextSortDirection: string) => void;
+    onSort?: (
+        event: MouseEvent<HTMLElement>,
+        field: string,
+        nextSortDirection: 'asc' | 'desc',
+    ) => void;
     resizeColumnDisabled?: boolean;
     minColumnWidth?: string | number;
     maxColumnWidth?: string | number;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2454

## Changes proposed in this PR:
- fix: types in onSort prop of the Table to be more strict (nextSortdirection must be the same as the prop sortDirection asc | desc)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
