### PR TITLE
feat: add strong password input prop size

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -175,7 +175,7 @@ Button.propTypes = {
     id: PropTypes.string,
     /** If it is set to true, then a loading symbol is displayed. */
     isLoading: PropTypes.bool,
-    /** The size of the button. Valid values are small, and large. This value defaults to medium. */
+    /** The size of the button. Valid values are small, medium and large. This value defaults to medium. */
     size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 

--- a/src/components/Input/styled/input.js
+++ b/src/components/Input/styled/input.js
@@ -147,6 +147,15 @@ const Input = attachThemeAttrs(styled.input)`
             box-shadow: ${props.shadows.error};
             padding: 0 1rem;
             outline: 0;
+            ${props.size === 'large' &&
+                `
+                    padding: 0 1.2rem;
+                `};
+        
+            ${props.size === 'small' &&
+                `
+                    padding: 0 0.8rem;
+                `};
         }
 
         &[disabled] {

--- a/src/components/StrongPasswordInput/index.d.ts
+++ b/src/components/StrongPasswordInput/index.d.ts
@@ -32,6 +32,7 @@ export interface StrongPasswordInputProps extends BaseProps {
     id?: string;
     passwordState?: 'weak' | 'average' | 'strong';
     passwordStateLabels?: PasswordStateLabels;
+    size?: 'small' | 'medium' | 'large';
 }
 
 export default function(props: StrongPasswordInputProps): JSX.Element | null;

--- a/src/components/StrongPasswordInput/index.js
+++ b/src/components/StrongPasswordInput/index.js
@@ -45,6 +45,7 @@ const StrongPasswordInput = React.forwardRef((props, ref) => {
         labelAlignment,
         hideLabel,
         iconPosition,
+        size,
     } = useReduxForm(props);
 
     const inputId = useUniqueIdentifier('input');
@@ -83,6 +84,7 @@ const StrongPasswordInput = React.forwardRef((props, ref) => {
                         iconPosition={iconPosition}
                         readOnly={readOnly}
                         error={error}
+                        size={size}
                     >
                         {icon}
                     </StyledIconContainer>
@@ -112,6 +114,7 @@ const StrongPasswordInput = React.forwardRef((props, ref) => {
                     error={error}
                     status={status}
                     ref={inputRef}
+                    size={size}
                 />
             </RelativeElement>
             <StrengthBar passwordState={passwordState} passwordStateLabels={passwordStateLabels} />
@@ -187,6 +190,8 @@ StrongPasswordInput.propTypes = {
         average: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
         strong: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     }),
+    /** The size of the input. Valid values are small, medium, and large. */
+    size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 
 StrongPasswordInput.defaultProps = {
@@ -216,6 +221,7 @@ StrongPasswordInput.defaultProps = {
     hideLabel: false,
     passwordState: undefined,
     passwordStateLabels: undefined,
+    size: 'medium',
 };
 
 export default StrongPasswordInput;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2476 

## Changes proposed in this PR:
- feat: add strong password input prop size

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
