### PR TITLE
fix: make the label on the inputable components more bigger when the size=large

### DIFF
--- a/src/components/ButtonGroupPicker/__test__/buttonGroupPicker.spec.js
+++ b/src/components/ButtonGroupPicker/__test__/buttonGroupPicker.spec.js
@@ -18,6 +18,7 @@ describe('<ButtonGroupPicker />', () => {
             hideLabel: false,
             as: 'legend',
             variant: 'default',
+            size: 'medium',
         });
     });
 

--- a/src/components/CodeInput/__test__/codeInput.spec.js
+++ b/src/components/CodeInput/__test__/codeInput.spec.js
@@ -33,6 +33,7 @@ describe('<CodeInput />', () => {
             hideLabel: false,
             as: 'legend',
             variant: 'default',
+            size: 'medium',
         });
     });
     it('should have bottomHelpText rendered if is sent as param', () => {

--- a/src/components/CounterInput/index.js
+++ b/src/components/CounterInput/index.js
@@ -103,6 +103,7 @@ const CounterInput = React.forwardRef((props, ref) => {
                 inputId={inputId}
                 readOnly={isReadOnly}
                 id={labelId}
+                size={size}
             />
             <RelativeElement>
                 <ButtonContainer iconPosition="left" readOnly={readOnly} error={error}>

--- a/src/components/CurrencyInput/index.js
+++ b/src/components/CurrencyInput/index.js
@@ -144,6 +144,7 @@ const CurrencyInput = forwardRef((props, ref) => {
                 inputId={inputId}
                 readOnly={isReadOnly}
                 id={labelId}
+                size={size}
             />
             <RelativeElement>
                 <RenderIf isTrue={icon}>

--- a/src/components/FileSelector/__test__/fileSelector.spec.js
+++ b/src/components/FileSelector/__test__/fileSelector.spec.js
@@ -50,6 +50,7 @@ describe('<FileSelector />', () => {
             inputId: expect.any(String),
             id: expect.any(String),
             variant: 'default',
+            size: 'medium',
         });
     });
 

--- a/src/components/Input/inputBase/__test__/input.spec.js
+++ b/src/components/Input/inputBase/__test__/input.spec.js
@@ -82,6 +82,7 @@ describe('<InputBase/>', () => {
             hideLabel: false,
             inputId: expect.any(String),
             variant: 'default',
+            size: 'medium',
         });
     });
     it('should toggle the password visibility', () => {

--- a/src/components/Input/inputBase/index.js
+++ b/src/components/Input/inputBase/index.js
@@ -139,6 +139,7 @@ export default class InputBase extends Component {
                     inputId={this.inputId}
                     readOnly={isReadOnly}
                     id={this.getInlineTextLabelId()}
+                    size={size}
                 />
                 <RelativeElement>
                     <RenderIf isTrue={icon}>

--- a/src/components/Input/label/index.d.ts
+++ b/src/components/Input/label/index.d.ts
@@ -11,6 +11,7 @@ export interface LabelProps {
     variant?: 'default' | 'inverse';
     hideLabel?: boolean;
     as?: string;
+    size?: 'small' | 'medium' | 'large';
 }
 
 export default function(props: LabelProps): JSX.Element | null;

--- a/src/components/Input/label/index.js
+++ b/src/components/Input/label/index.js
@@ -17,6 +17,7 @@ export default function Label(props) {
         hideLabel,
         variant,
         as,
+        size,
     } = props;
     if (hideLabel) {
         return (
@@ -37,6 +38,7 @@ export default function Label(props) {
                 as={as}
                 id={id}
                 variant={variant}
+                size={size}
             >
                 <RequiredAsterisk required={required} />
                 {label}
@@ -56,6 +58,7 @@ Label.propTypes = {
     hideLabel: PropTypes.bool,
     as: PropTypes.string,
     variant: PropTypes.oneOf(['default', 'inverse']),
+    size: PropTypes.oneOf(['small', 'medium', 'large']),
 };
 
 Label.defaultProps = {
@@ -69,4 +72,5 @@ Label.defaultProps = {
     hideLabel: false,
     as: undefined,
     variant: 'default',
+    size: 'medium',
 };

--- a/src/components/Input/label/labelText.js
+++ b/src/components/Input/label/labelText.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { FONT_SIZE_TEXT_MEDIUM } from '../../../styles/fontSizes';
+import { FONT_SIZE_TEXT_LARGE, FONT_SIZE_TEXT_MEDIUM } from '../../../styles/fontSizes';
 import { MARGIN_MEDIUM } from '../../../styles/margins';
 import { PADDING_MEDIUM } from '../../../styles/paddings';
 import attachThemeAttrs from '../../../styles/helpers/attachThemeAttrs';
@@ -70,6 +70,11 @@ const Label = attachThemeAttrs(styled.label).attrs(props => {
         `
         color: ${props.inverse.text};
     `}
+    ${props =>
+        props.size === 'large' &&
+        `
+            font-size: ${FONT_SIZE_TEXT_LARGE};
+        `};
 `;
 
 export { labelAlignmentMap };

--- a/src/components/Input/pickerInput/__test__/input.spec.js
+++ b/src/components/Input/pickerInput/__test__/input.spec.js
@@ -76,6 +76,7 @@ describe('<PickerInput/>', () => {
             labelAlignment: 'center',
             inputId: expect.any(String),
             variant: 'default',
+            size: 'medium',
         });
     });
     it('should render StyledPickerInput when readOnly is not passed', () => {

--- a/src/components/Input/pickerInput/index.js
+++ b/src/components/Input/pickerInput/index.js
@@ -124,6 +124,7 @@ export default class Input extends Component {
                     inputId={this.inputId}
                     readOnly={readOnly}
                     id={this.getInlineTextLabelId()}
+                    size={size}
                 />
                 <RelativeElement>
                     <RenderIf isTrue={icon}>

--- a/src/components/Lookup/__test__/lookup.spec.js
+++ b/src/components/Lookup/__test__/lookup.spec.js
@@ -33,6 +33,7 @@ describe('<Lookup />', () => {
             hideLabel: false,
             inputId: expect.any(String),
             variant: 'default',
+            size: 'medium',
         });
     });
     it('should render the Options menu when there are options and the input is focused', () => {

--- a/src/components/Lookup/index.js
+++ b/src/components/Lookup/index.js
@@ -479,6 +479,7 @@ class Lookup extends Component {
                     required={required}
                     inputId={this.inputId}
                     readOnly={readOnly}
+                    size={size}
                 />
 
                 <RenderIf isTrue={currentValue}>
@@ -541,6 +542,7 @@ class Lookup extends Component {
                             error={errorValue}
                             isLoading={isLoading}
                             variant={variant}
+                            size={size}
                         />
                         <InternalOverlay
                             isVisible={isLookupOpen}

--- a/src/components/PercentInput/index.js
+++ b/src/components/PercentInput/index.js
@@ -140,6 +140,7 @@ const PercentInput = forwardRef((props, ref) => {
                 inputId={inputId}
                 readOnly={isReadOnly}
                 id={labelId}
+                size={size}
             />
             <RelativeElement>
                 <RenderIf isTrue={icon}>

--- a/src/components/PhoneInput/index.js
+++ b/src/components/PhoneInput/index.js
@@ -187,6 +187,7 @@ const PhoneInput = React.forwardRef((props, ref) => {
                 inputId={inputId}
                 readOnly={readOnly}
                 id={labelId}
+                size={size}
             />
             <StyledInputContainer
                 disabled={disabled}

--- a/src/components/Picklist/index.js
+++ b/src/components/Picklist/index.js
@@ -255,6 +255,7 @@ class Picklist extends Component {
                         inputId={this.inputId}
                         readOnly={isReadOnly}
                         variant={labelVariant}
+                        size={size}
                     />
                 </RenderIf>
 

--- a/src/components/Select/__test__/select.spec.js
+++ b/src/components/Select/__test__/select.spec.js
@@ -39,6 +39,7 @@ describe('Select component', () => {
             hideLabel: false,
             inputId: expect.any(String),
             variant: 'default',
+            size: 'medium',
         });
     });
 });

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -78,6 +78,7 @@ class Select extends Component {
                     hideLabel={hideLabel}
                     required={required}
                     inputId={this.selectId}
+                    size={size}
                 />
                 <StyledInnerContainer error={error} disabled={disabled}>
                     <StyledSelect

--- a/src/components/StrongPasswordInput/__test__/strongPasswordInput.spec.js
+++ b/src/components/StrongPasswordInput/__test__/strongPasswordInput.spec.js
@@ -80,6 +80,7 @@ describe('<StrongPasswordInput />', () => {
             inputId: expect.any(String),
             id: expect.any(String),
             variant: 'default',
+            size: 'medium',
         });
     });
 

--- a/src/components/StrongPasswordInput/index.js
+++ b/src/components/StrongPasswordInput/index.js
@@ -76,6 +76,7 @@ const StrongPasswordInput = React.forwardRef((props, ref) => {
                 inputId={inputId}
                 readOnly={readOnly}
                 id={labelId}
+                size={size}
             />
 
             <RelativeElement>

--- a/src/components/Textarea/__test__/textarea.spec.js
+++ b/src/components/Textarea/__test__/textarea.spec.js
@@ -56,6 +56,7 @@ describe('<Textarea/>', () => {
             hideLabel: false,
             inputId: expect.any(String),
             variant: 'default',
+            size: 'medium',
         });
     });
     it('should have a inside div with id="headerTest"', () => {

--- a/src/components/VisualPicker/__test__/visualPicker.spec.js
+++ b/src/components/VisualPicker/__test__/visualPicker.spec.js
@@ -89,6 +89,7 @@ describe('<VisualPicker/>', () => {
             hideLabel: false,
             as: 'legend',
             variant: 'default',
+            size: 'medium',
         });
     });
 });

--- a/src/components/WeekDayPicker/__test__/weekDayPicker.spec.js
+++ b/src/components/WeekDayPicker/__test__/weekDayPicker.spec.js
@@ -19,6 +19,7 @@ describe('<WeekDayPicker />', () => {
             hideLabel: false,
             as: 'legend',
             variant: 'default',
+            size: 'medium',
         });
     });
     it('should render bottom help text when bottomHelpText prop is passed', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2507 

## Changes proposed in this PR:
-fix: make the label on the inputable components more bigger when the size='large'

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
