### PR TITLE
fix: remove capitalize in table header when using variant listview

### DIFF
--- a/src/components/Table/head/styled/headerContainer.js
+++ b/src/components/Table/head/styled/headerContainer.js
@@ -11,7 +11,7 @@ const StyledHeaderContainer = styled.div`
         props.theme.variant === 'listview' &&
         `
             justify-content: center;
-            text-transform: capitalize;
+            text-transform: none;
         `};
     ${props => props.headerAlignment === 'left' && 'justify-content: left;'}
     ${props => props.headerAlignment === 'center' && 'justify-content: center;'}

--- a/src/components/Table/readme.md
+++ b/src/components/Table/readme.md
@@ -743,12 +743,6 @@ function TableListView() {
                         sortable
                     />
                     <Column
-                        header={<StyledTaskHeader>Task</StyledTaskHeader>}
-                        field="task"
-                        component={Task}
-                        cellAlignment="left"
-                    />
-                    <Column
                         header="Priority"
                         field="priority"
                         component={Priority}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2544 

## Changes proposed in this PR:
- fix: remove capitalize in table header when using variant="listview"

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
