### PR TITLE
fix: standardize style of AM and PM output in DateTimePicker component

### DIFF
--- a/src/components/DateTimePicker/__test__/pickerModal.spec.js
+++ b/src/components/DateTimePicker/__test__/pickerModal.spec.js
@@ -19,6 +19,10 @@ describe('<DateTimePickerModal/>', () => {
         const component = mount(<DateTimePickerModal isOpen value={value} />);
         expect(component.find('TimeSelect').props().value).toBe('08:48 PM');
     });
+    it('should have a time period of "PM" and not "p. m."', () => {
+        const component = mount(<DateTimePickerModal isOpen locale="es-ES" value={value} />);
+        expect(component.find('h2').text()).toBe('24/10/2019 08:48 PM');
+    });
     xit('should set 12:00 AM to TimeSelect when value is null and date is changed', () => {
         const component = mount(<DateTimePickerModal isOpen />);
         component

--- a/src/components/DateTimePicker/helpers/formatDateTime.js
+++ b/src/components/DateTimePicker/helpers/formatDateTime.js
@@ -18,10 +18,16 @@ export default function formatDateTime(
             const options = FORMATS[formatStyle] || FORMATS.medium;
             const value = typeof date === 'string' ? new Date(date) : date;
             const timeFormat = hour24 ? timeFormat24h : timeFormat12h;
-            return new Intl.DateTimeFormat(locale, {
+            const intlDate = new Intl.DateTimeFormat(locale, {
                 ...options,
                 ...timeFormat,
             }).format(value);
+            if (!hour24) {
+                const dayPeriod = value.getHours() >= 12 ? 'PM' : 'AM';
+                const lastDigit = /(\d)[^\d]*$/.exec(intlDate).index;
+                return `${intlDate.substring(0, lastDigit + 1)} ${dayPeriod}`;
+            }
+            return intlDate;
         } catch (error) {
             console.error(error);
             return '';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2400

## Changes proposed in this PR:
-fix: standardize style of AM and PM output in DateTimePicker component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
