### PR TITLE
fix: add padding to the first cell of the third step in import record flow component

### DIFF
--- a/src/components/ImportRecordsFlow/stepThree/styled/databaseFieldCell.js
+++ b/src/components/ImportRecordsFlow/stepThree/styled/databaseFieldCell.js
@@ -9,7 +9,7 @@ import {
 const DatabaseFieldContent = attachThemeAttrs(styled.div)`
     background: ${props => props.palette.brand.light};
     color: ${props => props.palette.text.main};
-    margin: 8px 20px 8px 12px;
+    margin: 8px 20px 8px 0;
     border-radius: 8px;
     padding-left: 12px;
     line-height: 30px;

--- a/src/components/ImportRecordsFlow/stepThree/styled/databaseFieldCell.js
+++ b/src/components/ImportRecordsFlow/stepThree/styled/databaseFieldCell.js
@@ -9,7 +9,7 @@ import {
 const DatabaseFieldContent = attachThemeAttrs(styled.div)`
     background: ${props => props.palette.brand.light};
     color: ${props => props.palette.text.main};
-    margin: 8px 20px 8px 0;
+    margin: 8px 20px 8px 12px;
     border-radius: 8px;
     padding-left: 12px;
     line-height: 30px;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2601

## Changes proposed in this PR:
-add padding to the first cell of the third step in import record flow component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
