### PR TITLE
fix: fix typo in default props of CounterInput component

### DIFF
--- a/src/components/CounterInput/index.js
+++ b/src/components/CounterInput/index.js
@@ -253,6 +253,6 @@ CounterInput.defaultProps = {
     bottomHelpText: null,
     className: undefined,
     style: undefined,
-    size: 'mediun',
+    size: 'medium',
     borderRadius: 'rounded',
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: Fix a typo in the default props of the CounterInput component.

## Changes proposed in this PR:
- Fix a typo in the default props of the CounterInput component

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
