### PR TITLE
fix: add `step` to props to `Input` component

### DIFF
--- a/src/components/Input/index.d.ts
+++ b/src/components/Input/index.d.ts
@@ -38,6 +38,7 @@ export interface InputProps extends BaseProps {
     iconPosition?: IconPosition;
     max?: number | string;
     min?: number | string;
+    step?: number | string;
     maxLength?: number;
     minLength?: number;
     bottomHelpText?: ReactNode;

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -91,6 +91,8 @@ Input.propTypes = {
     /** Describes the position of the icon with respect to body. Options include left and right.
      * This value defaults to left. */
     iconPosition: PropTypes.oneOf(['left', 'right']),
+    /** Specifies the increment step allowed in the field. */
+    step: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     /** Specifies the minimum value allowed in the field. */
     max: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     /** Specifies the maximum value allowed in the field. */
@@ -162,6 +164,7 @@ Input.defaultProps = {
     iconPosition: 'left',
     max: undefined,
     min: undefined,
+    step: undefined,
     maxLength: undefined,
     minLength: undefined,
     bottomHelpText: null,

--- a/src/components/Input/inputBase/index.js
+++ b/src/components/Input/inputBase/index.js
@@ -108,6 +108,7 @@ export default class InputBase extends Component {
             type,
             max,
             min,
+            step,
             maxLength,
             minLength,
             pattern,
@@ -171,6 +172,7 @@ export default class InputBase extends Component {
                         required={required}
                         max={max}
                         min={min}
+                        step={step}
                         maxLength={maxLength}
                         minLength={minLength}
                         pattern={pattern}
@@ -233,6 +235,7 @@ InputBase.propTypes = {
     iconPosition: PropTypes.oneOf(['left', 'right']),
     max: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     min: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    step: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     maxLength: PropTypes.number,
     minLength: PropTypes.number,
     bottomHelpText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
@@ -272,6 +275,7 @@ InputBase.defaultProps = {
     iconPosition: 'left',
     max: undefined,
     min: undefined,
+    step: undefined,
     maxLength: undefined,
     minLength: undefined,
     bottomHelpText: null,


### PR DESCRIPTION
fix: #

## Changes proposed in this PR:
- add prop `step` to Input component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
