### PR TITLE
fix: borderRadius styles on Modal's closeButton

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -187,6 +187,7 @@ export default class Modal extends Component {
                                 title="Close"
                                 onClick={this.closeModal}
                                 ref={this.buttonRef}
+                                borderRadius={borderRadius}
                             />
                         </RenderIf>
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: #2625 

## Changes proposed in this PR:
- fix borderRadius styles on Modal's closeButton

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
