### PR TITLE
fix: form submit when click a day in Calendar component

### DIFF
--- a/src/components/Calendar/day.js
+++ b/src/components/Calendar/day.js
@@ -83,6 +83,7 @@ function DayComponent(props) {
                 <StyledDayButton
                     ref={buttonRef}
                     tabIndex={tabIndex}
+                    type="button"
                     onClick={() => onChange(date)}
                     onMouseEnter={() => privateOnHover(date)}
                     isSelected={isSelected}


### PR DESCRIPTION
fix: #

## Changes proposed in this PR:
- set type="button" to calendar day

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
