### PR TITLE
chore: add types to exports objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,11 +59,13 @@
     "module": "./esm/index.js",
     "exports": {
         ".": {
+            "types": "./index.d.ts",
             "module": "./esm/index.js",
             "require": "./index.js",
             "default": "./esm/index.js"
         },
         "./*": {
+            "types": "./index.d.ts",
             "module": "./esm/*",
             "require": "./*",
             "default": "./esm/*"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

## Changes proposed in this PR:

This allows packages that are declared as `type: module` and uses `tsc` to transpile to work properly. Otherwise the types cannot be found.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/nexxtway/react-rainbow/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

@nexxtway/react-rainbow
